### PR TITLE
Add taxonomy-driven filters and auto family inference

### DIFF
--- a/project/server/index.js
+++ b/project/server/index.js
@@ -655,46 +655,83 @@ app.get('/api/relaciones', (req, res) => {
 });
 
 // ---------- RELACIONAR MANUAL ----------
-app.post('/api/relacionar-manual', (req, res) => {
+app.post('/api/relacionar-manual', async (req, res) => {
   const db = req.ctx.db;
-  const { id_lista_interna, ids_lista_precios, criterio } = req.body;
+  const { id_lista_interna, ids_lista_precios, criterio, familia, subfamilia } = req.body || {};
 
   if (!id_lista_interna || !Array.isArray(ids_lista_precios) || ids_lista_precios.length === 0) {
     return res.status(400).json({ error: 'Datos incompletos o inválidos' });
   }
 
   const placeholders = ids_lista_precios.map(() => '(?, ?, ?)').join(', ');
-  const params = ids_lista_precios.flatMap(id => [id, id_lista_interna, criterio]);
+  const criterioValor = criterio ?? 'manual';
+  const params = ids_lista_precios.flatMap((id) => [id, id_lista_interna, criterioValor]);
 
-  const sql = `
+  const insertSql = `
     INSERT INTO relacion_articulos (id_lista_precios, id_lista_interna, criterio_relacion)
     VALUES ${placeholders}
   `;
 
-  db.run(sql, params, function (err) {
-    if (err) {
-      console.error('Error al vincular productos:', err.message);
-      return res.status(500).json({ error: 'Error al vincular productos' });
-    }
+  try {
+    await runDb(db, insertSql, params);
+  } catch (err) {
+    console.error('Error al vincular productos:', err.message);
+    return res.status(500).json({ error: 'Error al vincular productos' });
+  }
 
-    const deleteExternosSql = `
-      DELETE FROM articulos_no_relacionados WHERE id_lista_precios IN (${ids_lista_precios.map(() => '?').join(',')})
-    `;
-    db.run(deleteExternosSql, ids_lista_precios, (delErr) => {
-      if (delErr) {
-        console.error('Error eliminando artículos no relacionados (externos):', delErr.message);
-      }
-    });
-
-    const deleteInternoSql = `DELETE FROM articulos_gampack_no_relacionados WHERE id_lista_interna = ?`;
-    db.run(deleteInternoSql, [id_lista_interna], (delErr) => {
-      if (delErr) {
-        console.error('Error eliminando artículo no relacionado (interno):', delErr.message);
-      }
-    });
-
-    res.status(200).json({ success: true });
+  const deleteExternosSql = `
+    DELETE FROM articulos_no_relacionados WHERE id_lista_precios IN (${ids_lista_precios.map(() => '?').join(',')})
+  `;
+  runDb(db, deleteExternosSql, ids_lista_precios).catch((delErr) => {
+    console.error('Error eliminando artículos no relacionados (externos):', delErr.message);
   });
+
+  const deleteInternoSql = `DELETE FROM articulos_gampack_no_relacionados WHERE id_lista_interna = ?`;
+  runDb(db, deleteInternoSql, [id_lista_interna]).catch((delErr) => {
+    console.error('Error eliminando artículo no relacionado (interno):', delErr.message);
+  });
+
+  const normalizedFamily = normalizeWhitespace(familia || '');
+  const normalizedSubfamily = normalizeWhitespace(subfamilia || '');
+
+  if (normalizedFamily) {
+    const applyUpdate = async (sql, values) => {
+      try {
+        await runDb(db, sql, values);
+      } catch (error) {
+        if (error?.message && /no such column/i.test(error.message)) {
+          console.warn('Columna de familia/subfamilia no encontrada, omitiendo actualización.');
+          return;
+        }
+        throw error;
+      }
+    };
+
+    const subfamilyValue = normalizedSubfamily || null;
+
+    const updateInternaSql = `
+      UPDATE lista_interna
+         SET familia = ?,
+             subfamilia = COALESCE(?, subfamilia)
+       WHERE id_interno = ?
+    `;
+
+    const updateExternosSql = `
+      UPDATE lista_precios
+         SET familia = ?,
+             subfamilia = COALESCE(?, subfamilia)
+       WHERE id_externo IN (${ids_lista_precios.map(() => '?').join(',')})
+    `;
+
+    try {
+      await applyUpdate(updateInternaSql, [normalizedFamily, subfamilyValue, id_lista_interna]);
+      await applyUpdate(updateExternosSql, [normalizedFamily, subfamilyValue, ...ids_lista_precios]);
+    } catch (err) {
+      console.error('Error actualizando familia/subfamilia:', err.message);
+    }
+  }
+
+  return res.status(200).json({ success: true });
 });
 
 // ---------- Alta producto (manual) ----------

--- a/project/src/lib/taxonomy.ts
+++ b/project/src/lib/taxonomy.ts
@@ -1,0 +1,204 @@
+export type TaxonomyNode = {
+  value: string;
+  label: string;
+  subfamilies: { value: string; label: string }[];
+};
+
+type KeywordRule = {
+  pattern: RegExp;
+  family: string;
+  subfamily?: string;
+};
+
+const TAXONOMY_DATA: TaxonomyNode[] = [
+  {
+    value: 'Desechables',
+    label: 'Desechables',
+    subfamilies: [
+      { value: 'Vasos', label: 'Vasos' },
+      { value: 'Bandejas', label: 'Bandejas' },
+      { value: 'Platos', label: 'Platos' },
+      { value: 'Potes', label: 'Potes' },
+      { value: 'Servilletas', label: 'Servilletas' },
+      { value: 'Cubiertos', label: 'Cubiertos' },
+      { value: 'Sorbetes', label: 'Sorbetes' },
+      { value: 'Torteras', label: 'Torteras' },
+    ],
+  },
+  {
+    value: 'Empaque & Embalaje',
+    label: 'Empaque & Embalaje',
+    subfamilies: [
+      { value: 'Bolsas', label: 'Bolsas' },
+      { value: 'Bobinas', label: 'Bobinas' },
+      { value: 'Films', label: 'Films' },
+      { value: 'Rollos', label: 'Rollos' },
+      { value: 'Estuches', label: 'Estuches & Blisters' },
+      { value: 'Cajas', label: 'Cajas' },
+      { value: 'Etiquetas', label: 'Etiquetas' },
+    ],
+  },
+  {
+    value: 'Repostería & Gastronomía',
+    label: 'Repostería & Gastronomía',
+    subfamilies: [
+      { value: 'Reposteria', label: 'Accesorios de repostería' },
+      { value: 'Panificados', label: 'Panificados' },
+      { value: 'Bandejas', label: 'Bandejas especiales' },
+    ],
+  },
+  {
+    value: 'Limpieza',
+    label: 'Limpieza',
+    subfamilies: [
+      { value: 'Quimicos', label: 'Químicos & accesorios' },
+      { value: 'Papel', label: 'Papel' },
+      { value: 'Aromas', label: 'Aromatización' },
+      { value: 'Guantes', label: 'Guantes' },
+    ],
+  },
+  {
+    value: 'Papeleria',
+    label: 'Papelería',
+    subfamilies: [
+      { value: 'Escritura', label: 'Escritura & oficina' },
+      { value: 'Cuadernos', label: 'Cuadernos & blocks' },
+      { value: 'Archivos', label: 'Archivos & sobres' },
+      { value: 'Cintas', label: 'Cintas' },
+      { value: 'Laminas', label: 'Láminas' },
+    ],
+  },
+  {
+    value: 'Otros',
+    label: 'Otros',
+    subfamilies: [
+      { value: 'Accesorios', label: 'Accesorios' },
+      { value: 'Decoracion', label: 'Decoración' },
+      { value: 'Varios', label: 'Varios' },
+    ],
+  },
+];
+
+const removeDiacritics = (value: string) =>
+  value.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+
+const normalizeName = (value: string) =>
+  removeDiacritics(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+
+const KEYWORD_RULES: KeywordRule[] = [
+  // ===== Desechables =====
+  { pattern: /\bvasos?\b/, family: 'Desechables', subfamily: 'Vasos' },
+  { pattern: /\btapas?\s+vasos?\b/, family: 'Desechables', subfamily: 'Vasos' },
+  { pattern: /\bbandejas?\b/, family: 'Desechables', subfamily: 'Bandejas' },
+  { pattern: /\bplatos?\b/, family: 'Desechables', subfamily: 'Platos' },
+  { pattern: /\bpotes?\b/, family: 'Desechables', subfamily: 'Potes' },
+  { pattern: /\bservilletas?\b/, family: 'Desechables', subfamily: 'Servilletas' },
+  { pattern: /\bcubiertos?\b/, family: 'Desechables', subfamily: 'Cubiertos' },
+  { pattern: /\bcuchar(as?|itas?)\b/, family: 'Desechables', subfamily: 'Cubiertos' },
+  { pattern: /\btenedore?s?\b/, family: 'Desechables', subfamily: 'Cubiertos' },
+  { pattern: /\bcuchill(os|as)?\b/, family: 'Desechables', subfamily: 'Cubiertos' },
+  { pattern: /\bsorbete?s?\b/, family: 'Desechables', subfamily: 'Sorbetes' },
+  { pattern: /\btorteras?\b/, family: 'Desechables', subfamily: 'Torteras' },
+
+  // ===== Empaque & Embalaje =====
+  { pattern: /\bbolsas?\b/, family: 'Empaque & Embalaje', subfamily: 'Bolsas' },
+  { pattern: /\bbobinas?\b/, family: 'Empaque & Embalaje', subfamily: 'Bobinas' },
+  { pattern: /\bfilm?s?\b/, family: 'Empaque & Embalaje', subfamily: 'Films' },
+  { pattern: /\bstretch\b/, family: 'Empaque & Embalaje', subfamily: 'Films' },
+  { pattern: /\brollos?\b/, family: 'Empaque & Embalaje', subfamily: 'Rollos' },
+  { pattern: /\bestuches?\b/, family: 'Empaque & Embalaje', subfamily: 'Estuches' },
+  { pattern: /\bblister\b/, family: 'Empaque & Embalaje', subfamily: 'Estuches' },
+  { pattern: /\bcajas?\b/, family: 'Empaque & Embalaje', subfamily: 'Cajas' },
+  { pattern: /\betiquetas?\b/, family: 'Empaque & Embalaje', subfamily: 'Etiquetas' },
+
+  // ===== Repostería & Gastronomía =====
+  { pattern: /\brepost(eria|ero|er[íi]a)\b/, family: 'Repostería & Gastronomía', subfamily: 'Reposteria' },
+  { pattern: /\bpirotin(es)?\b/, family: 'Repostería & Gastronomía', subfamily: 'Reposteria' },
+  { pattern: /\btelgopor\b/, family: 'Repostería & Gastronomía', subfamily: 'Reposteria' },
+  { pattern: /\bmarmitas?\b/, family: 'Repostería & Gastronomía', subfamily: 'Reposteria' },
+  { pattern: /\bplantill(as?|a)\b/, family: 'Repostería & Gastronomía', subfamily: 'Reposteria' },
+  { pattern: /\bpalillos?\b/, family: 'Repostería & Gastronomía', subfamily: 'Reposteria' },
+  { pattern: /\bpinches?\b/, family: 'Repostería & Gastronomía', subfamily: 'Reposteria' },
+  { pattern: /\bbizcoch?uelo?s?\b/, family: 'Repostería & Gastronomía', subfamily: 'Panificados' },
+  { pattern: /\bbudin(es)?\b/, family: 'Repostería & Gastronomía', subfamily: 'Panificados' },
+  { pattern: /\bobleas?\b/, family: 'Repostería & Gastronomía', subfamily: 'Panificados' },
+  { pattern: /\bpan\s+dulce\b/, family: 'Repostería & Gastronomía', subfamily: 'Panificados' },
+  { pattern: /\bpizzas?\b/, family: 'Repostería & Gastronomía', subfamily: 'Panificados' },
+  { pattern: /\bbocaditos?\b/, family: 'Repostería & Gastronomía', subfamily: 'Panificados' },
+
+  // ===== Limpieza =====
+  { pattern: /\blimpiador(es)?\b/, family: 'Limpieza', subfamily: 'Quimicos' },
+  { pattern: /\blustramuebles?\b/, family: 'Limpieza', subfamily: 'Quimicos' },
+  { pattern: /\baerosoles?\b/, family: 'Limpieza', subfamily: 'Quimicos' },
+  { pattern: /\bdispensers?\b/, family: 'Limpieza', subfamily: 'Quimicos' },
+  { pattern: /\bresiduos?\b/, family: 'Limpieza', subfamily: 'Quimicos' },
+  { pattern: /\bpapel\s+higienic[oa]\b/, family: 'Limpieza', subfamily: 'Papel' },
+  { pattern: /\btoallas?\s+intercaladas\b/, family: 'Limpieza', subfamily: 'Papel' },
+  { pattern: /\baromatizad(or|ores|ora|oras)\b/, family: 'Limpieza', subfamily: 'Aromas' },
+  { pattern: /\bspray\b/, family: 'Limpieza', subfamily: 'Aromas' },
+  { pattern: /\bdifusores?\b/, family: 'Limpieza', subfamily: 'Aromas' },
+  { pattern: /\bperfumes?\s+textiles\b/, family: 'Limpieza', subfamily: 'Aromas' },
+  { pattern: /\bguantes?\b/, family: 'Limpieza', subfamily: 'Guantes' },
+
+  // ===== Papelería =====
+  { pattern: /\bboligrafos?\b/, family: 'Papeleria', subfamily: 'Escritura' },
+  { pattern: /\blapices?\b/, family: 'Papeleria', subfamily: 'Escritura' },
+  { pattern: /\bmarcadores?\b/, family: 'Papeleria', subfamily: 'Escritura' },
+  { pattern: /\bresaltadores?\b/, family: 'Papeleria', subfamily: 'Escritura' },
+  { pattern: /\btizas?\b/, family: 'Papeleria', subfamily: 'Escritura' },
+  { pattern: /\breglas?\b/, family: 'Papeleria', subfamily: 'Escritura' },
+  { pattern: /\bclips?\b/, family: 'Papeleria', subfamily: 'Escritura' },
+  { pattern: /\bcorrectores?\b/, family: 'Papeleria', subfamily: 'Escritura' },
+  { pattern: /\btijeras?\b/, family: 'Papeleria', subfamily: 'Escritura' },
+  { pattern: /\bcuadernos?\b/, family: 'Papeleria', subfamily: 'Cuadernos' },
+  { pattern: /\bblocks?\b/, family: 'Papeleria', subfamily: 'Cuadernos' },
+  { pattern: /\bcarpetas?\b/, family: 'Papeleria', subfamily: 'Archivos' },
+  { pattern: /\bsobres?\b/, family: 'Papeleria', subfamily: 'Archivos' },
+  { pattern: /\bfolios?\b/, family: 'Papeleria', subfamily: 'Archivos' },
+  { pattern: /\bcintas?\b/, family: 'Papeleria', subfamily: 'Cintas' },
+  { pattern: /\blaminas?\b/, family: 'Papeleria', subfamily: 'Laminas' },
+
+  // ===== Otros =====
+  { pattern: /\baccesorios?\b/, family: 'Otros', subfamily: 'Accesorios' },
+  { pattern: /\bporta\s+bobinas?\b/, family: 'Otros', subfamily: 'Accesorios' },
+  { pattern: /\btripodes?\b/, family: 'Otros', subfamily: 'Accesorios' },
+  { pattern: /\bconos?\s+para\s+papas\b/, family: 'Otros', subfamily: 'Accesorios' },
+  { pattern: /\bmonos?\b/, family: 'Otros', subfamily: 'Decoracion' },
+  { pattern: /\bblondas?\b/, family: 'Otros', subfamily: 'Decoracion' },
+  { pattern: /\bindividuales?\b/, family: 'Otros', subfamily: 'Decoracion' },
+  { pattern: /\bcaminos?\b/, family: 'Otros', subfamily: 'Decoracion' },
+  { pattern: /\bnepacos?\b/, family: 'Otros', subfamily: 'Varios' },
+  { pattern: /\broscas?\b/, family: 'Otros', subfamily: 'Varios' },
+  { pattern: /\broute\s*66\b/, family: 'Otros', subfamily: 'Varios' },
+  { pattern: /\bsenaletica\b/, family: 'Otros', subfamily: 'Varios' },
+  { pattern: /\btouch\b/, family: 'Otros', subfamily: 'Varios' },
+  { pattern: /\bhueveras?\b/, family: 'Otros', subfamily: 'Varios' },
+  { pattern: /\bhilos?\b/, family: 'Otros', subfamily: 'Varios' },
+  { pattern: /\bsisal\b/, family: 'Otros', subfamily: 'Varios' },
+];
+
+export const TAXONOMY = TAXONOMY_DATA;
+
+export function inferFamilyByName(name: string): { family: string; subfamily?: string } | null {
+  if (!name) return null;
+  const normalized = normalizeName(name);
+  if (!normalized) return null;
+
+  for (const rule of KEYWORD_RULES) {
+    if (rule.pattern.test(normalized)) {
+      return rule.subfamily
+        ? { family: rule.family, subfamily: rule.subfamily }
+        : { family: rule.family };
+    }
+  }
+
+  return null;
+}
+
+export function getFamilyNode(familyValue: string | null | undefined) {
+  if (!familyValue) return undefined;
+  return TAXONOMY.find((item) => item.value === familyValue);
+}

--- a/project/src/screens/venta/CompareScreen.tsx
+++ b/project/src/screens/venta/CompareScreen.tsx
@@ -2,10 +2,12 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { Navigation } from '../../components/Navigation';
 import { Input } from '../../components/Input';
 import { Table } from '../../components/Table';
+import { Select } from '../../components/Select';
 import { PriceComparison } from '../../tipos/database';
 import { Search, List, LayoutGrid, CalendarDays, XCircle } from 'lucide-react';
 import { Screen } from '../../types';
 import { apiFetch } from '../../lib/api';
+import { TAXONOMY } from '../../lib/taxonomy';
 
 interface CompareScreenProps {
   onNavigate: (screen: Screen) => void;
@@ -20,9 +22,6 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
   // Filtros
   const [dateFrom, setDateFrom] = useState(''); // YYYY-MM-DD
   const [dateTo, setDateTo] = useState('');     // YYYY-MM-DD
-  const [familia, setFamilia] = useState('');   // texto libre (compatibilidad)
-
-  // NUEVO: selects guiados
   const [famGenSel, setFamGenSel] = useState('');
   const [famEspSel, setFamEspSel] = useState('');
 
@@ -84,13 +83,13 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
       loadComparisons(searchTerm);
     }, 300);
     return () => clearTimeout(delay);
-  }, [searchTerm, dateFrom, dateTo, familia, famGenSel, famEspSel, dateRangeInvalid]);
+  }, [searchTerm, dateFrom, dateTo, famGenSel, famEspSel, dateRangeInvalid]);
 
   // Construye el valor que mandamos como `familia` al backend
   const buildFamiliaQuery = () => {
     if (famGenSel && famEspSel) return `${famGenSel} > ${famEspSel}`; // p.ej. "Desechables > Vasos"
     if (famGenSel) return famGenSel;                                   // p.ej. "Desechables"
-    return familia;                                                    // texto libre existente
+    return '';
   };
 
   const loadComparisons = async (search = '') => {
@@ -181,10 +180,28 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
     setSearchTerm('');
     setDateFrom('');
     setDateTo('');
-    setFamilia('');
     setFamGenSel('');
     setFamEspSel('');
   };
+
+  const familyOptions = useMemo(() => [
+    { value: '', label: 'Todas las familias' },
+    ...TAXONOMY.map((family) => ({ value: family.value, label: family.label })),
+  ], []);
+
+  const subfamilyOptions = useMemo(() => {
+    if (!famGenSel) return [{ value: '', label: 'Todas las subfamilias' }];
+    const family = TAXONOMY.find((item) => item.value === famGenSel);
+    if (!family) return [{ value: '', label: 'Todas las subfamilias' }];
+    return [
+      { value: '', label: 'Todas las subfamilias' },
+      ...family.subfamilies.map((sub) => ({ value: sub.value, label: sub.label })),
+    ];
+  }, [famGenSel]);
+
+  useEffect(() => {
+    setFamEspSel('');
+  }, [famGenSel]);
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-[#0b0f1a] p-6">
@@ -192,7 +209,7 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
         <Navigation onBack={() => onNavigate('home')} title="Comparar Gampacks" />
 
         {/* Filtros */}
-        <div className="grid grid-cols-1 md:grid-cols-6 gap-4 mb-2">
+        <div className="grid grid-cols-1 md:grid-cols-7 gap-4 mb-2">
           <div className="md:col-span-2">
             <label className="block text-xs text-gray-600 dark:text-white/80 mb-1">Buscar</label>
             <div className="relative">
@@ -217,10 +234,25 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
             <Input type="date" value={dateTo} onChange={(e) => setDateTo(e.target.value)} className="w-full dark:bg-white/10 dark:text-white dark:placeholder-white/60 dark:border-white/10 dark:focus:border-white/30 dark:focus:ring-white/20" />
           </div>
 
-          {/* Input libre (compatibilidad) */}
           <div>
-            <label className="block text-xs text-gray-600 dark:text-white/80 mb-1">Familia (texto libre)</label>
-            <Input placeholder="Ej: bolsas, films..." value={familia} onChange={(e) => setFamilia(e.target.value)} className="dark:bg-white/10 dark:text-white dark:placeholder-white/60 dark:border-white/10 dark:focus:border-white/30 dark:focus:ring-white/20" />
+            <label className="block text-xs text-gray-600 dark:text-white/80 mb-1">Familia</label>
+            <Select
+              value={famGenSel}
+              onChange={(e) => setFamGenSel(e.target.value)}
+              options={familyOptions}
+              className="dark:bg-white/10 dark:text-white dark:border-white/10 dark:focus:border-white/30 dark:focus:ring-white/20 text-sm"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs text-gray-600 dark:text-white/80 mb-1">Subfamilia</label>
+            <Select
+              value={famEspSel}
+              onChange={(e) => setFamEspSel(e.target.value)}
+              options={subfamilyOptions}
+              disabled={!famGenSel}
+              className={`dark:bg-white/10 dark:text-white dark:border-white/10 dark:focus:border-white/30 dark:focus:ring-white/20 text-sm ${!famGenSel ? 'opacity-60' : ''}`}
+            />
           </div>
 
           <div className="flex items-end">

--- a/project/src/screens/venta/UnmatchedEquivalencesScreen.tsx
+++ b/project/src/screens/venta/UnmatchedEquivalencesScreen.tsx
@@ -4,6 +4,7 @@ import { Navigation } from '../../components/Navigation';
 import { Screen } from '../../types';
 import { apiFetch } from '../../lib/api';
 import { Trash2 } from 'lucide-react';
+import { inferFamilyByName } from '../../lib/taxonomy';
 
 /* ---------- Similaridad por trigramas + coseno (solo nombres) ---------- */
 function sanitizeText(s: string) {
@@ -70,6 +71,42 @@ function classHeader(active: boolean) {
 }
 const normalizeStr = (v: any) => String(v ?? '').toLowerCase().trim();
 const cmp = (a: any, b: any) => (a < b ? -1 : a > b ? 1 : 0);
+
+type InferredFamily = ReturnType<typeof inferFamilyByName>;
+
+const pickFamilyForLink = (internal?: InternalItem | null, externals: ExternalItem[] = []): InferredFamily => {
+  const internalName = internal?.nom_interno?.trim();
+  if (internalName) {
+    const inferred = inferFamilyByName(internalName);
+    if (inferred) return inferred;
+  }
+
+  for (const ext of externals) {
+    const externalName = ext.nom_externo?.trim();
+    if (!externalName) continue;
+    const inferred = inferFamilyByName(externalName);
+    if (inferred) return inferred;
+  }
+
+  return null;
+};
+
+const buildLinkPayload = (internal: InternalItem, externals: ExternalItem[], criterio: string) => {
+  const uniqueIds = Array.from(new Set(externals.map((item) => item.id_externo)));
+  const payload: Record<string, any> = {
+    id_lista_interna: internal.id_interno,
+    ids_lista_precios: uniqueIds,
+    criterio,
+  };
+
+  const inferred = pickFamilyForLink(internal, externals);
+  if (inferred) {
+    payload.familia = inferred.family;
+    if (inferred.subfamily) payload.subfamilia = inferred.subfamily;
+  }
+
+  return payload;
+};
 
 /* ---------- Input de búsqueda ---------- */
 const SearchInput: React.FC<{ value: string; onChange: (v: string) => void; placeholder: string; }> =
@@ -226,8 +263,9 @@ export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen
   const acceptSuggestion = async (s: Suggestion) => {
     try {
       const res = await apiFetch('/api/relacionar-manual', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id_lista_interna: s.internal.id_interno, ids_lista_precios: [s.external.id_externo], criterio: 'manual' }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildLinkPayload(s.internal, [s.external], 'manual')),
       });
       if (res.ok) removeFromStateAfterLink(s.internal, s.external);
       else alert(`Error: ${(await res.json().catch(() => ({} as any)))?.message || 'No se pudo vincular'}`);
@@ -243,19 +281,24 @@ export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen
     if (suggestions.length === 0) return;
     setBulkBusy(true);
     try {
-      const byInternal = new Map<number, { internal: InternalItem; extIds: number[] }>();
-      suggestions.forEach(s => {
+      const byInternal = new Map<number, { internal: InternalItem; externals: ExternalItem[] }>();
+      suggestions.forEach((s) => {
         const key = s.internal.id_interno;
-        if (!byInternal.has(key)) byInternal.set(key, { internal: s.internal, extIds: [] });
-        byInternal.get(key)!.extIds.push(s.external.id_externo);
+        if (!byInternal.has(key)) byInternal.set(key, { internal: s.internal, externals: [] });
+        const entry = byInternal.get(key)!;
+        if (!entry.externals.find((ext) => ext.id_externo === s.external.id_externo)) {
+          entry.externals.push(s.external);
+        }
       });
 
-      for (const { internal, extIds } of byInternal.values()) {
+      for (const { internal, externals } of byInternal.values()) {
         const res = await apiFetch('/api/relacionar-manual', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id_lista_interna: internal.id_interno, ids_lista_precios: extIds, criterio: 'manual' }),
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(buildLinkPayload(internal, externals, 'manual')),
         });
         if (!res.ok) throw new Error('No se pudo vincular en lote');
+        const extIds = externals.map((ext) => ext.id_externo);
         setExternals(prev => prev.filter(e => !extIds.includes(e.id_externo)));
         setInternals(prev => prev.filter(i => i.id_interno !== internal.id_interno));
         setSuggestions(prev => prev.filter(s => s.internal.id_interno !== internal.id_interno));
@@ -494,10 +537,11 @@ export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen
               onClick={async () => {
                 if (!selectedInternal || selectedExternals.length === 0) { alert('Seleccioná un producto Gampack y al menos un proveedor'); return; }
                 try {
+                  const payload = buildLinkPayload(selectedInternal, selectedExternals, 'manual');
                   const res = await apiFetch('/api/relacionar-manual', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ id_lista_interna: selectedInternal.id_interno, ids_lista_precios: selectedExternals.map(e => e.id_externo), criterio: 'manual' }),
+                    body: JSON.stringify(payload),
                   });
                   if (res.ok) {
                     setExternals(prev => prev.filter(e => !selectedExternals.some(se => se.id_externo === e.id_externo)));


### PR DESCRIPTION
## Summary
- add a reusable taxonomy module with macrofamilies, subfamilies and name-based inference helpers
- swap the free-text family filter in the ventas compare screen for cascading family/subfamily selects backed by the taxonomy
- infer and persist family information when new equivalences are created, both client side and server side

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d13f71b94c832d8415e1154c8136e1