### PR TITLE
Configure environment variables for hosting setup

### DIFF
--- a/project/server/index.js
+++ b/project/server/index.js
@@ -11,10 +11,15 @@ const { tenantMiddleware } = require('./middleware/tenant');
 const app = express();
 
 // ===== Middlewares base =====
+const envOrigins = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
 const allowedOrigins = [
-  'http://localhost:5173',
+  ...envOrigins,
   'https://supplier-price-calculator-and-comparator.vercel.app',
-  'supplier-price-calculator-and-compa.vercel.app'
+  'https://supplier-price-calculator-and-compa.vercel.app'
 ];
 
 app.use(cors({

--- a/project/server/server.js
+++ b/project/server/server.js
@@ -1,6 +1,6 @@
 const app = require('./index');
 
-const PORT = 4000;
+const PORT = process.env.PORT || 4000;
 app.listen(PORT, () => {
   console.log(`Servidor corriendo en puerto ${PORT}`);
 });

--- a/project/src/lib/api.ts
+++ b/project/src/lib/api.ts
@@ -6,10 +6,20 @@ export function currentRole() {
   }
 }
 
-const BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:4000";
+const API_BASE_URL = (() => {
+  const raw = import.meta.env.VITE_API_URL ?? '';
+  if (!raw) return '';
+  return raw.endsWith('/') ? raw.slice(0, -1) : raw;
+})();
+
+export { API_BASE_URL };
 
 export async function apiFetch(path: string, init: RequestInit = {}) {
-  const url = path.startsWith("http") ? path : `${BASE_URL}${path}`;
+  const url = path.startsWith('http')
+    ? path
+    : API_BASE_URL
+      ? `${API_BASE_URL}${path.startsWith('/') ? path : `/${path}`}`
+      : path;
   const headers = new Headers(init.headers || {});
   if (!headers.has("X-Role")) headers.set("X-Role", currentRole());
   return fetch(url, { ...init, headers, credentials: "include" });

--- a/project/src/screens/compra/LoginScreen.tsx
+++ b/project/src/screens/compra/LoginScreen.tsx
@@ -2,8 +2,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Eye, EyeOff, Lock, Mail, Loader2, Moon, Sun, ShieldCheck } from 'lucide-react';
 import { apiFetch } from '../../lib/api';
 
-const BASE_URL = 'http://localhost:4000';
-
 interface Props {
   onLoginSuccess: (role: 'compra' | 'venta') => void;
 }
@@ -55,7 +53,7 @@ export const LoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
     setError(null);
     setLoading(true);
     try {
-      const res = await apiFetch(`${BASE_URL}/api/login`, {
+      const res = await apiFetch('/api/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password }),

--- a/project/src/screens/venta/LoginScreen.tsx
+++ b/project/src/screens/venta/LoginScreen.tsx
@@ -2,8 +2,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Eye, EyeOff, Lock, Mail, Loader2, Moon, Sun, ShieldCheck } from 'lucide-react';
 import { apiFetch } from '../../lib/api';
 
-const BASE_URL = 'http://localhost:4000';
-
 interface Props {
   onLoginSuccess: (role: 'compra' | 'venta') => void;
 }
@@ -55,7 +53,7 @@ export const LoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
     setError(null);
     setLoading(true);
     try {
-      const res = await apiFetch(`${BASE_URL}/api/login`, {
+      const res = await apiFetch('/api/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password }),

--- a/project/src/screens/venta/ManualEntryScreen.tsx
+++ b/project/src/screens/venta/ManualEntryScreen.tsx
@@ -18,8 +18,6 @@ interface FormData {
   date: string;
 }
 
-const BASE_URL = 'http://localhost:4000';
-
 // 🔧 NUEVO: normaliza cualquier forma de producto (manual o Excel)
 function normalizeProduct(p: any) {
   const company =
@@ -127,7 +125,7 @@ const UploadFamiliesCard: React.FC<{ onDone?: () => void }> = ({ onDone }) => {
       const fd = new FormData();
       fd.append('file', file);
 
-      const res = await apiFetch(`${BASE_URL}/api/imports/familias`, {
+      const res = await apiFetch('/api/imports/familias', {
         method: 'POST',
         body: fd,
       });
@@ -241,7 +239,7 @@ export const ManualEntryScreen: React.FC<ManualEntryScreenProps> = ({ onNavigate
 
   const checkProductExists = async (): Promise<boolean> => {
     try {
-      const res = await apiFetch(`${BASE_URL}/api/check-product`, {
+      const res = await apiFetch('/api/check-product', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -277,7 +275,7 @@ export const ManualEntryScreen: React.FC<ManualEntryScreenProps> = ({ onNavigate
     setSearching(true);
     try {
       const res = await apiFetch(
-        `${BASE_URL}/api/products/search/manual?by=${searchCriteria}&q=${encodeURIComponent(query)}`
+        `/api/products/search/manual?by=${searchCriteria}&q=${encodeURIComponent(query)}`
       );
       if (!res.ok) throw new Error(await res.text());
       const data = await res.json();
@@ -307,7 +305,7 @@ export const ManualEntryScreen: React.FC<ManualEntryScreenProps> = ({ onNavigate
     const companyType = inferCompanyType(formData.company);
 
     try {
-      const response = await apiFetch(`${BASE_URL}/api/products`, {
+      const response = await apiFetch('/api/products', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -367,7 +365,7 @@ export const ManualEntryScreen: React.FC<ManualEntryScreenProps> = ({ onNavigate
     const companyType = inferCompanyType(formData.company);
 
     try {
-      const response = await apiFetch(`${BASE_URL}/api/products`, {
+      const response = await apiFetch('/api/products', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/project/vite.config.ts
+++ b/project/vite.config.ts
@@ -1,19 +1,26 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  optimizeDeps: {
-    exclude: ['lucide-react', '@sqlite.org/sqlite-wasm'],
-  },
-  server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:4000',  // Cambia 3000 por el puerto de tu backend Express
-        changeOrigin: true,
-        secure: false,
-      },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const apiProxyTarget = env.VITE_API_URL ? env.VITE_API_URL.replace(/\/$/, '') : undefined;
+
+  return {
+    plugins: [react()],
+    optimizeDeps: {
+      exclude: ['lucide-react', '@sqlite.org/sqlite-wasm'],
     },
-  },
+    server: apiProxyTarget
+      ? {
+          proxy: {
+            '/api': {
+              target: apiProxyTarget,
+              changeOrigin: true,
+              secure: false,
+            },
+          },
+        }
+      : undefined,
+  };
 });


### PR DESCRIPTION
## Summary
- read the Express port from `process.env.PORT` with a default fallback
- load allowed CORS origins and Vite proxy target from environment variables for deployment
- update the React client to use `VITE_API_URL` for every API request instead of hardcoded localhost URLs

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dbc06d26d4832d896b4b0fc7e96fc0