### PR TITLE
Prevent duplicate products and track update month

### DIFF
--- a/project/server/index.js
+++ b/project/server/index.js
@@ -91,6 +91,17 @@ function ensureYMD(value) {
   return parsed.toISOString().slice(0, 10);
 }
 
+function ensureYearMonth(value) {
+  if (value == null) return null;
+  if (typeof value === 'string') {
+    const ymMatch = value.match(/^(\d{4})-(\d{2})/);
+    if (ymMatch) return `${ymMatch[1]}-${ymMatch[2]}`;
+  }
+  const ymd = ensureYMD(value);
+  if (ymd) return ymd.slice(0, 7);
+  return null;
+}
+
 function normalizeRowDates(row, fields = []) {
   if (!row || typeof row !== 'object') return row;
   const copy = { ...row };
@@ -157,6 +168,99 @@ function parsePositiveInt(raw, defaultValue, min, max) {
 
 function normalizeWhitespace(value) {
   return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function normalizeNameForExactMatch(value) {
+  if (!value) return '';
+  return normalizeWhitespace(value).toLowerCase();
+}
+
+async function findInternalByExactName(db, normalizedName) {
+  if (!normalizedName) return null;
+  return getDbRow(
+    db,
+    `SELECT * FROM lista_interna
+     WHERE nom_interno IS NOT NULL
+       AND LOWER(REGEXP_REPLACE(TRIM(nom_interno), '\\s+', ' ', 'g')) = $1
+     ORDER BY id_interno ASC
+     LIMIT 1`,
+    [normalizedName]
+  );
+}
+
+async function findExternalByExactName(db, normalizedName, normalizedSupplier = null) {
+  if (!normalizedName) return null;
+  const params = [normalizedName];
+  const clauses = [
+    `SELECT * FROM lista_precios
+     WHERE nom_externo IS NOT NULL
+       AND LOWER(REGEXP_REPLACE(TRIM(nom_externo), '\\s+', ' ', 'g')) = $1
+       AND LOWER(TRIM(tipo_empresa)) = 'proveedor'`
+  ];
+  if (normalizedSupplier) {
+    clauses.push('AND LOWER(TRIM(proveedor)) = $2');
+    params.push(normalizedSupplier);
+  }
+  clauses.push('ORDER BY id_externo ASC\nLIMIT 1');
+  return getDbRow(db, clauses.join('\n'), params);
+}
+
+async function createRelationAndClean(db, idListaPrecios, idListaInterna, criterio = 'automatic') {
+  if (!idListaPrecios || !idListaInterna) {
+    return { created: false, reason: 'missing_ids' };
+  }
+
+  const existingPair = await getDbRow(
+    db,
+    `SELECT id FROM relacion_articulos WHERE id_lista_precios = $1 AND id_lista_interna = $2`,
+    [idListaPrecios, idListaInterna]
+  );
+  if (existingPair) {
+    await runDb(db, `DELETE FROM articulos_no_relacionados WHERE id_lista_precios = $1`, [idListaPrecios]);
+    await runDb(db, `DELETE FROM articulos_gampack_no_relacionados WHERE id_lista_interna = $1`, [idListaInterna]);
+    return { created: true, relationId: existingPair.id, alreadyExisted: true };
+  }
+
+  const existingForExternal = await getDbRow(
+    db,
+    `SELECT id, id_lista_interna FROM relacion_articulos WHERE id_lista_precios = $1 LIMIT 1`,
+    [idListaPrecios]
+  );
+  if (existingForExternal) {
+    return {
+      created: false,
+      reason: 'external_already_related',
+      conflictingRelationId: existingForExternal.id,
+      conflictingInternalId: existingForExternal.id_lista_interna,
+    };
+  }
+
+  const existingForInternal = await getDbRow(
+    db,
+    `SELECT id, id_lista_precios FROM relacion_articulos WHERE id_lista_interna = $1 LIMIT 1`,
+    [idListaInterna]
+  );
+  if (existingForInternal) {
+    return {
+      created: false,
+      reason: 'internal_already_related',
+      conflictingRelationId: existingForInternal.id,
+      conflictingExternalId: existingForInternal.id_lista_precios,
+    };
+  }
+
+  const insertedRelation = await getDbRow(
+    db,
+    `INSERT INTO relacion_articulos (id_lista_precios, id_lista_interna, criterio_relacion)
+     VALUES ($1, $2, $3)
+     RETURNING id`,
+    [idListaPrecios, idListaInterna, criterio]
+  );
+
+  await runDb(db, `DELETE FROM articulos_no_relacionados WHERE id_lista_precios = $1`, [idListaPrecios]);
+  await runDb(db, `DELETE FROM articulos_gampack_no_relacionados WHERE id_lista_interna = $1`, [idListaInterna]);
+
+  return { created: true, relationId: insertedRelation?.id ?? null, alreadyExisted: false };
 }
 
 function removeDiacritics(value) {
@@ -643,6 +747,7 @@ function createNoRelacionadosHandler(tipo) {
             lp.proveedor AS proveedor,
             lp.precio_final AS precio_final,
             lp.fecha AS fecha,
+            lp.mes_actualizacion AS mes_actualizacion,
             anr.motivo AS motivo,
             CASE WHEN anr.id_lista_precios IS NULL THEN 0 ELSE 1 END AS es_pendiente,
             LOWER(lp.nom_externo) AS nombre_lower
@@ -682,6 +787,7 @@ function createNoRelacionadosHandler(tipo) {
           li.nom_interno AS nom_interno,
           li.precio_final AS precio_final,
           li.fecha AS fecha,
+          li.mes_actualizacion AS mes_actualizacion,
           agnr.motivo AS motivo,
           CASE WHEN agnr.id_lista_interna IS NULL THEN 0 ELSE 1 END AS es_pendiente,
           LOWER(li.nom_interno) AS nombre_lower
@@ -844,47 +950,10 @@ app.post('/api/products', async (req, res) => {
 
   const normalizedCode = normalizeCode(productCode);
   const normalizedNameKey = normalizeForKey(productName);
+  const normalizedExactName = normalizeNameForExactMatch(productName);
   const nameLikePattern = buildNameLikePattern(productName);
   const normalizedCompany = company ? company.toLowerCase() : '';
   const hasCompany = Boolean(normalizedCompany);
-
-  async function createRelationAndClean(idListaPrecios, idListaInterna, criterio = 'automatic') {
-    const existingPair = await getDbRow(
-      db,
-      `SELECT id FROM relacion_articulos WHERE id_lista_precios = $1 AND id_lista_interna = $2`,
-      [idListaPrecios, idListaInterna]
-    );
-    if (existingPair) {
-      return { created: true, relationId: existingPair.id, alreadyExisted: true };
-    }
-
-    const existingForInternal = await getDbRow(
-      db,
-      `SELECT id, id_lista_precios FROM relacion_articulos WHERE id_lista_interna = $1 LIMIT 1`,
-      [idListaInterna]
-    );
-    if (existingForInternal) {
-      return {
-        created: false,
-        reason: 'internal_already_related',
-        conflictingRelationId: existingForInternal.id,
-        conflictingExternalId: existingForInternal.id_lista_precios,
-      };
-    }
-
-    const insertedRelation = await getDbRow(
-      db,
-      `INSERT INTO relacion_articulos (id_lista_precios, id_lista_interna, criterio_relacion)
-       VALUES ($1, $2, $3)
-       RETURNING id`,
-      [idListaPrecios, idListaInterna, criterio]
-    );
-
-    await runDb(db, `DELETE FROM articulos_no_relacionados WHERE id_lista_precios = $1`, [idListaPrecios]);
-    await runDb(db, `DELETE FROM articulos_gampack_no_relacionados WHERE id_lista_interna = $1`, [idListaInterna]);
-
-    return { created: true, relationId: insertedRelation?.id ?? null, alreadyExisted: false };
-  }
 
   const pickBestNameMatch = (targetName, candidates, getName) => {
     let best = null;
@@ -912,6 +981,13 @@ app.post('/api/products', async (req, res) => {
       );
       if (match) {
         return { row: match, criterion: 'codigo' };
+      }
+    }
+
+    if (normalizedExactName) {
+      const exactByName = await findInternalByExactName(db, normalizedExactName);
+      if (exactByName) {
+        return { row: exactByName, criterion: 'nombre_exact' };
       }
     }
 
@@ -953,6 +1029,13 @@ app.post('/api/products', async (req, res) => {
       }
     }
 
+    if (normalizedExactName) {
+      const exactByName = await findExternalByExactName(db, normalizedExactName, useCompanyFilter ? normalizedCompany : null);
+      if (exactByName) {
+        return { row: exactByName, criterion: 'nombre_exact' };
+      }
+    }
+
     if (normalizedNameKey && nameLikePattern) {
       const params = [nameLikePattern];
       const clauses = [
@@ -977,6 +1060,8 @@ app.post('/api/products', async (req, res) => {
 
   try {
     if (companyType === 'Proveedor') {
+      const normalizedMonth = ensureYearMonth(normalizedDate) || normalizedDate.slice(0, 7);
+
       const exact = await getDbRow(
         db,
         `SELECT * FROM lista_precios
@@ -988,15 +1073,23 @@ app.post('/api/products', async (req, res) => {
         [productCode, company, companyType]
       );
 
-      if (exact) {
-        const storedDate = ensureYMD(exact.fecha);
+      let existing = exact;
+      if (!existing && normalizedExactName && normalizedCompany) {
+        existing = await findExternalByExactName(db, normalizedExactName, normalizedCompany);
+      }
+
+      if (existing) {
+        const storedDate = ensureYMD(existing.fecha);
+        const storedMonth = ensureYearMonth(existing.mes_actualizacion || existing.fecha);
         const needsUpdate =
-          normalizeWhitespace(exact.cod_externo || '') !== productCode ||
-          normalizeWhitespace(exact.nom_externo || '') !== productName ||
-          Number(exact.precio_final) !== Number(finalPrice) ||
+          normalizeWhitespace(existing.cod_externo || '') !== productCode ||
+          normalizeWhitespace(existing.nom_externo || '') !== productName ||
+          Number(existing.precio_final) !== Number(finalPrice) ||
           storedDate !== normalizedDate ||
-          normalizeWhitespace(exact.proveedor || '') !== company ||
-          normalizeWhitespace(exact.tipo_empresa || '') !== companyType;
+          normalizeWhitespace(existing.proveedor || '') !== company ||
+          normalizeWhitespace(existing.tipo_empresa || '') !== companyType ||
+          storedMonth !== normalizedMonth;
+
         if (needsUpdate) {
           await runDb(
             db,
@@ -1006,11 +1099,22 @@ app.post('/api/products', async (req, res) => {
                  precio_final = $3,
                  tipo_empresa = $4,
                  fecha = $5,
-                 proveedor = $6
-             WHERE id_externo = $7`,
-            [productCode || null, productName, finalPrice, companyType, normalizedDate, company, exact.id_externo]
+                 proveedor = $6,
+                 mes_actualizacion = $7
+             WHERE id_externo = $8`,
+            [
+              productCode || null,
+              productName,
+              finalPrice,
+              companyType,
+              normalizedDate,
+              company,
+              normalizedMonth,
+              existing.id_externo,
+            ]
           );
         }
+
         return res.status(200).json({ success: true, updated: true, message: 'Producto actualizado' });
       }
 
@@ -1018,10 +1122,10 @@ app.post('/api/products', async (req, res) => {
       try {
         inserted = await getDbRow(
           db,
-          `INSERT INTO lista_precios (cod_externo, nom_externo, precio_final, tipo_empresa, fecha, proveedor)
-           VALUES ($1, $2, $3, $4, $5, $6)
+          `INSERT INTO lista_precios (cod_externo, nom_externo, precio_final, tipo_empresa, fecha, proveedor, mes_actualizacion)
+           VALUES ($1, $2, $3, $4, $5, $6, $7)
            RETURNING id_externo`,
-          [productCode || null, productName, finalPrice, companyType, normalizedDate, company]
+          [productCode || null, productName, finalPrice, companyType, normalizedDate, company, normalizedMonth]
         );
       } catch (err) {
         if (err?.code === '23505' && productCode) {
@@ -1031,7 +1135,7 @@ app.post('/api/products', async (req, res) => {
              WHERE cod_externo IS NOT NULL
                AND LOWER(TRIM(cod_externo)) = LOWER($1)
                AND LOWER(TRIM(proveedor)) = LOWER($2)
-             LIMIT 1`,
+            LIMIT 1`,
             [productCode, company]
           );
           if (conflict) {
@@ -1042,9 +1146,10 @@ app.post('/api/products', async (req, res) => {
                    precio_final = $2,
                    tipo_empresa = $3,
                    fecha = $4,
-                   proveedor = $5
-               WHERE id_externo = $6`,
-              [productName, finalPrice, companyType, normalizedDate, company, conflict.id_externo]
+                   proveedor = $5,
+                   mes_actualizacion = $6
+               WHERE id_externo = $7`,
+              [productName, finalPrice, companyType, normalizedDate, company, normalizedMonth, conflict.id_externo]
             );
             return res.status(200).json({ success: true, updated: true, message: 'Producto actualizado' });
           }
@@ -1060,7 +1165,7 @@ app.post('/api/products', async (req, res) => {
 
       let relationResult = null;
       if (internalMatch?.row && linkAsEquivalent !== false) {
-        relationResult = await createRelationAndClean(newId, internalMatch.row.id_interno, internalMatch.criterion);
+        relationResult = await createRelationAndClean(db, newId, internalMatch.row.id_interno, internalMatch.criterion);
         if (relationResult?.created) {
           return res.status(201).json({ success: true, message: 'Producto creado y relacionado' });
         }
@@ -1072,6 +1177,9 @@ app.post('/api/products', async (req, res) => {
         }
         if (relationResult?.reason === 'internal_already_related') {
           return 'Coincidencia automática omitida: el producto interno ya está relacionado';
+        }
+        if (relationResult?.reason === 'external_already_related') {
+          return 'Coincidencia automática omitida: el producto del proveedor ya está relacionado';
         }
         return 'Usuario rechazó sugerencia de relación';
       })();
@@ -1092,6 +1200,8 @@ app.post('/api/products', async (req, res) => {
     }
 
     if (companyType === 'Gampack') {
+      const normalizedMonth = ensureYearMonth(normalizedDate) || normalizedDate.slice(0, 7);
+
       const exact = productCode
         ? await getDbRow(
             db,
@@ -1103,13 +1213,20 @@ app.post('/api/products', async (req, res) => {
           )
         : null;
 
-      if (exact) {
-        const storedDate = ensureYMD(exact.fecha);
+      let existing = exact;
+      if (!existing && normalizedExactName) {
+        existing = await findInternalByExactName(db, normalizedExactName);
+      }
+
+      if (existing) {
+        const storedDate = ensureYMD(existing.fecha);
+        const storedMonth = ensureYearMonth(existing.mes_actualizacion || existing.fecha);
         const needsUpdate =
-          normalizeWhitespace(exact.cod_interno || '') !== productCode ||
-          normalizeWhitespace(exact.nom_interno || '') !== productName ||
-          Number(exact.precio_final) !== Number(finalPrice) ||
-          storedDate !== normalizedDate;
+          normalizeWhitespace(existing.cod_interno || '') !== productCode ||
+          normalizeWhitespace(existing.nom_interno || '') !== productName ||
+          Number(existing.precio_final) !== Number(finalPrice) ||
+          storedDate !== normalizedDate ||
+          storedMonth !== normalizedMonth;
         if (needsUpdate) {
           await runDb(
             db,
@@ -1117,9 +1234,10 @@ app.post('/api/products', async (req, res) => {
              SET cod_interno = $1,
                  nom_interno = $2,
                  precio_final = $3,
-                 fecha = $4
-             WHERE id_interno = $5`,
-            [productCode || null, productName, finalPrice, normalizedDate, exact.id_interno]
+                 fecha = $4,
+                 mes_actualizacion = $5
+             WHERE id_interno = $6`,
+            [productCode || null, productName, finalPrice, normalizedDate, normalizedMonth, existing.id_interno]
           );
         }
         return res.status(200).json({ success: true, updated: true, message: 'Producto actualizado' });
@@ -1129,10 +1247,10 @@ app.post('/api/products', async (req, res) => {
       try {
         inserted = await getDbRow(
           db,
-          `INSERT INTO lista_interna (cod_interno, nom_interno, precio_final, fecha)
-           VALUES ($1, $2, $3, $4)
+          `INSERT INTO lista_interna (cod_interno, nom_interno, precio_final, fecha, mes_actualizacion)
+           VALUES ($1, $2, $3, $4, $5)
            RETURNING id_interno`,
-          [productCode || null, productName, finalPrice, normalizedDate]
+          [productCode || null, productName, finalPrice, normalizedDate, normalizedMonth]
         );
       } catch (err) {
         if (err?.code === '23505' && productCode) {
@@ -1141,7 +1259,7 @@ app.post('/api/products', async (req, res) => {
             `SELECT * FROM lista_interna
              WHERE cod_interno IS NOT NULL
                AND LOWER(TRIM(cod_interno)) = LOWER($1)
-             LIMIT 1`,
+            LIMIT 1`,
             [productCode]
           );
           if (conflict) {
@@ -1150,9 +1268,10 @@ app.post('/api/products', async (req, res) => {
               `UPDATE lista_interna
                SET nom_interno = $1,
                    precio_final = $2,
-                   fecha = $3
-               WHERE id_interno = $4`,
-              [productName, finalPrice, normalizedDate, conflict.id_interno]
+                   fecha = $3,
+                   mes_actualizacion = $4
+               WHERE id_interno = $5`,
+              [productName, finalPrice, normalizedDate, normalizedMonth, conflict.id_interno]
             );
             return res.status(200).json({ success: true, updated: true, message: 'Producto actualizado' });
           }
@@ -1168,7 +1287,7 @@ app.post('/api/products', async (req, res) => {
 
       let relationResult = null;
       if (externalMatch?.row && linkAsEquivalent !== false) {
-        relationResult = await createRelationAndClean(externalMatch.row.id_externo, newId, externalMatch.criterion);
+        relationResult = await createRelationAndClean(db, externalMatch.row.id_externo, newId, externalMatch.criterion);
         if (relationResult?.created) {
           return res.status(201).json({ success: true, message: 'Producto creado y relacionado' });
         }
@@ -1180,6 +1299,9 @@ app.post('/api/products', async (req, res) => {
         }
         if (relationResult?.reason === 'internal_already_related') {
           return 'Coincidencia automática omitida: el producto interno ya está relacionado';
+        }
+        if (relationResult?.reason === 'external_already_related') {
+          return 'Coincidencia automática omitida: el producto del proveedor ya está relacionado';
         }
         return 'Usuario rechazó sugerencia de relación';
       })();
@@ -1558,11 +1680,13 @@ app.post('/api/imports/lista-precios', upload.single('file'), (req, res) => {
       }
 
       const today = new Date().toISOString().slice(0, 10);
+      const todayMonth = ensureYearMonth(today) || today.slice(0, 7);
 
       let inserted = 0;
       let updated = 0;
       let updatedPriceChanged = 0;
       let skipped = 0;
+      let autoRelated = 0;
 
       const proveedorCanon = normalizeLabel(providerHint);
       const proveedorLower = normLower(providerHint);
@@ -1613,7 +1737,7 @@ app.post('/api/imports/lista-precios', upload.single('file'), (req, res) => {
         return byName || null;
       };
 
-      const upsertListaInterna = async ({ nombre, codigo, price, today }) => {
+      const upsertListaInterna = async ({ nombre, codigo, price, today, month }) => {
         const nombreN = normalizeLabel(nombre);
         const codigoN = codigo ? normalizeLabel(codigo) : null;
         const existing = await getExistingInterno({ codigo: codigoN, nombre: nombreN });
@@ -1621,26 +1745,26 @@ app.post('/api/imports/lista-precios', upload.single('file'), (req, res) => {
         if (existing?.id) {
           await run(
             `UPDATE lista_interna
-             SET nom_interno = $1, precio_final = $2, fecha = $3
-             WHERE id_interno = $4`,
-            [nombreN, price, today, existing.id]
+             SET nom_interno = $1, precio_final = $2, fecha = $3, mes_actualizacion = $4
+             WHERE id_interno = $5`,
+            [nombreN, price, today, month, existing.id]
           );
           updated++;
           if (existing.price !== price) updatedPriceChanged++;
           return existing.id;
         } else {
           const ins = await get(
-            `INSERT INTO lista_interna (nom_interno, cod_interno, precio_final, fecha)
-             VALUES ($1, $2, $3, $4)
+            `INSERT INTO lista_interna (nom_interno, cod_interno, precio_final, fecha, mes_actualizacion)
+             VALUES ($1, $2, $3, $4, $5)
              RETURNING id_interno AS id`,
-            [nombreN, codigoN, price, today]
+            [nombreN, codigoN, price, today, month]
           );
           inserted++;
           return ins.id;
         }
       };
 
-      const upsertListaPrecios = async ({ nombre, codigo, price, proveedorCanon, proveedorLower, today }) => {
+      const upsertListaPrecios = async ({ nombre, codigo, price, proveedorCanon, proveedorLower, today, month }) => {
         const nombreN = normalizeLabel(nombre);
         const codigoN = codigo ? normalizeLabel(codigo) : null;
         const existing = await getExistingExterno({ proveedorLower, codigo: codigoN, nombre: nombreN });
@@ -1648,19 +1772,19 @@ app.post('/api/imports/lista-precios', upload.single('file'), (req, res) => {
         if (existing?.id) {
           await run(
             `UPDATE lista_precios
-             SET nom_externo = $1, precio_final = $2, tipo_empresa = 'Proveedor', fecha = $3
-             WHERE id_externo = $4`,
-            [nombreN, price, today, existing.id]
+             SET nom_externo = $1, precio_final = $2, tipo_empresa = 'Proveedor', fecha = $3, mes_actualizacion = $4
+             WHERE id_externo = $5`,
+            [nombreN, price, today, month, existing.id]
           );
           updated++;
           if (existing.price !== price) updatedPriceChanged++;
           return existing.id;
         } else {
           const ins = await get(
-            `INSERT INTO lista_precios (nom_externo, cod_externo, precio_final, tipo_empresa, fecha, proveedor)
-             VALUES ($1, $2, $3, 'Proveedor', $4, $5)
+            `INSERT INTO lista_precios (nom_externo, cod_externo, precio_final, tipo_empresa, fecha, proveedor, mes_actualizacion)
+             VALUES ($1, $2, $3, 'Proveedor', $4, $5, $6)
              RETURNING id_externo AS id`,
-            [nombreN, codigoN, price, today, proveedorCanon]
+            [nombreN, codigoN, price, today, proveedorCanon, month]
           );
           inserted++;
           return ins.id;
@@ -1672,6 +1796,7 @@ app.post('/api/imports/lista-precios', upload.single('file'), (req, res) => {
         for (const r of rows) {
           const nombre = String(getCell(r, colNom) ?? '');
           const nombreN = normalizeLabel(nombre);
+          const nombreExactKey = normalizeNameForExactMatch(nombreN);
           const codigoRaw = colCod ? String(getCell(r, colCod) ?? '') : '';
           const codigo = normalizeLabel(codigoRaw) || null;
           const precioRaw = getCell(r, colPrecio);
@@ -1683,33 +1808,55 @@ app.post('/api/imports/lista-precios', upload.single('file'), (req, res) => {
           }
 
           if (isGampack) {
-            const idInterno = await upsertListaInterna({ nombre: nombreN, codigo, price, today });
+            const idInterno = await upsertListaInterna({ nombre: nombreN, codigo, price, today, month: todayMonth });
             if (idInterno) {
-              await run(
-                `INSERT INTO articulos_gampack_no_relacionados (id_lista_interna, motivo)
-                 VALUES ($1, $2)
-                 ON CONFLICT (id_lista_interna) DO NOTHING`,
-                [idInterno, 'Importado vía carga masiva']
-              );
+              let relationResult = null;
+              if (nombreExactKey) {
+                const externalMatch = await findExternalByExactName(db, nombreExactKey);
+                if (externalMatch?.id_externo) {
+                  relationResult = await createRelationAndClean(db, externalMatch.id_externo, idInterno, 'nombre_exact');
+                  if (relationResult?.created) autoRelated++;
+                }
+              }
+
+              if (!relationResult?.created) {
+                await run(
+                  `INSERT INTO articulos_gampack_no_relacionados (id_lista_interna, motivo)
+                   VALUES ($1, $2)
+                   ON CONFLICT (id_lista_interna) DO NOTHING`,
+                  [idInterno, 'Importado vía carga masiva']
+                );
+              }
             }
           } else {
             const idExterno = await upsertListaPrecios({
-              nombre: nombreN, codigo, price, proveedorCanon, proveedorLower, today
+              nombre: nombreN, codigo, price, proveedorCanon, proveedorLower, today, month: todayMonth
             });
             if (idExterno) {
-              await run(
-                `INSERT INTO articulos_no_relacionados (id_lista_precios, motivo)
-                 VALUES ($1, $2)
-                 ON CONFLICT (id_lista_precios) DO NOTHING`,
-                [idExterno, 'Importado vía carga masiva']
-              );
+              let relationResult = null;
+              if (nombreExactKey) {
+                const internalMatch = await findInternalByExactName(db, nombreExactKey);
+                if (internalMatch?.id_interno) {
+                  relationResult = await createRelationAndClean(db, idExterno, internalMatch.id_interno, 'nombre_exact');
+                  if (relationResult?.created) autoRelated++;
+                }
+              }
+
+              if (!relationResult?.created) {
+                await run(
+                  `INSERT INTO articulos_no_relacionados (id_lista_precios, motivo)
+                   VALUES ($1, $2)
+                   ON CONFLICT (id_lista_precios) DO NOTHING`,
+                  [idExterno, 'Importado vía carga masiva']
+                );
+              }
             }
           }
         }
 
         await run('COMMIT');
 
-        const message = `Importación finalizada: ${updated} modificados (${updatedPriceChanged} con cambio de precio) y ${inserted} nuevos.${skipped ? ` Omitidos: ${skipped}.` : ''}`;
+        const message = `Importación finalizada: ${updated} modificados (${updatedPriceChanged} con cambio de precio) y ${inserted} nuevos.${skipped ? ` Omitidos: ${skipped}.` : ''}${autoRelated ? ` Vinculados automáticamente: ${autoRelated}.` : ''}`;
 
         return res.json({
           ok: true,
@@ -1720,7 +1867,8 @@ app.post('/api/imports/lista-precios', upload.single('file'), (req, res) => {
             inserted,
             updated,
             updated_price_changed: updatedPriceChanged,
-            skipped
+            skipped,
+            auto_related: autoRelated
           },
           processed: inserted + updated,
           saved_to: isGampack ? 'articulos_gampack_no_relacionados' : 'articulos_no_relacionados',

--- a/project/server/schema.sql
+++ b/project/server/schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS lista_precios (
   tipo_empresa TEXT NOT NULL,
   fecha DATE NOT NULL,
   proveedor TEXT NOT NULL,
+  mes_actualizacion TEXT,
   familia TEXT
 );
 
@@ -38,8 +39,28 @@ CREATE TABLE IF NOT EXISTS lista_interna (
   cod_interno TEXT,
   precio_final NUMERIC(18, 4) NOT NULL,
   fecha DATE NOT NULL,
+  mes_actualizacion TEXT,
   familia TEXT
 );
+
+ALTER TABLE lista_precios
+  ADD COLUMN IF NOT EXISTS mes_actualizacion TEXT;
+ALTER TABLE lista_interna
+  ADD COLUMN IF NOT EXISTS mes_actualizacion TEXT;
+
+UPDATE lista_precios
+   SET mes_actualizacion = TO_CHAR(fecha, 'YYYY-MM')
+ WHERE mes_actualizacion IS NULL;
+UPDATE lista_interna
+   SET mes_actualizacion = TO_CHAR(fecha, 'YYYY-MM')
+ WHERE mes_actualizacion IS NULL;
+
+ALTER TABLE lista_precios
+  ALTER COLUMN mes_actualizacion SET NOT NULL,
+  ALTER COLUMN mes_actualizacion SET DEFAULT TO_CHAR(CURRENT_DATE, 'YYYY-MM');
+ALTER TABLE lista_interna
+  ALTER COLUMN mes_actualizacion SET NOT NULL,
+  ALTER COLUMN mes_actualizacion SET DEFAULT TO_CHAR(CURRENT_DATE, 'YYYY-MM');
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_li_cod_not_null
   ON lista_interna (cod_interno)
@@ -132,6 +153,7 @@ CREATE TABLE IF NOT EXISTS lista_precios (
   tipo_empresa TEXT NOT NULL,
   fecha DATE NOT NULL,
   proveedor TEXT NOT NULL,
+  mes_actualizacion TEXT,
   familia TEXT
 );
 
@@ -147,8 +169,28 @@ CREATE TABLE IF NOT EXISTS lista_interna (
   cod_interno TEXT,
   precio_final NUMERIC(18, 4) NOT NULL,
   fecha DATE NOT NULL,
+  mes_actualizacion TEXT,
   familia TEXT
 );
+
+ALTER TABLE lista_precios
+  ADD COLUMN IF NOT EXISTS mes_actualizacion TEXT;
+ALTER TABLE lista_interna
+  ADD COLUMN IF NOT EXISTS mes_actualizacion TEXT;
+
+UPDATE lista_precios
+   SET mes_actualizacion = TO_CHAR(fecha, 'YYYY-MM')
+ WHERE mes_actualizacion IS NULL;
+UPDATE lista_interna
+   SET mes_actualizacion = TO_CHAR(fecha, 'YYYY-MM')
+ WHERE mes_actualizacion IS NULL;
+
+ALTER TABLE lista_precios
+  ALTER COLUMN mes_actualizacion SET NOT NULL,
+  ALTER COLUMN mes_actualizacion SET DEFAULT TO_CHAR(CURRENT_DATE, 'YYYY-MM');
+ALTER TABLE lista_interna
+  ALTER COLUMN mes_actualizacion SET NOT NULL,
+  ALTER COLUMN mes_actualizacion SET DEFAULT TO_CHAR(CURRENT_DATE, 'YYYY-MM');
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_li_cod_not_null
   ON lista_interna (cod_interno)

--- a/project/src/screens/venta/UnmatchedEquivalencesScreen.tsx
+++ b/project/src/screens/venta/UnmatchedEquivalencesScreen.tsx
@@ -4,7 +4,7 @@ import { Navigation } from '../../components/Navigation';
 import { Screen } from '../../types';
 import { apiFetch } from '../../lib/api';
 import { Trash2 } from 'lucide-react';
-import { formatYMD, compareYMD } from '../../utils/date';
+import { formatYMD, compareYMD, formatYearMonth, compareYearMonth } from '../../utils/date';
 
 /* ---------- Similaridad por trigramas + coseno (solo nombres) ---------- */
 function sanitizeText(s: string) {
@@ -28,8 +28,8 @@ function tokenizeName(s: string) {
 }
 
 type SortDir = 'asc' | 'desc';
-type SortKeyExternal = 'cod_externo' | 'nom_externo' | 'proveedor' | 'fecha';
-type SortKeyInternal = 'cod_interno' | 'nom_interno' | 'fecha';
+type SortKeyExternal = 'cod_externo' | 'nom_externo' | 'proveedor' | 'fecha' | 'mes_actualizacion';
+type SortKeyInternal = 'cod_interno' | 'nom_interno' | 'fecha' | 'mes_actualizacion';
 
 type ExternalItem = {
   id_externo: number;
@@ -37,6 +37,7 @@ type ExternalItem = {
   nom_externo?: string | null;
   proveedor?: string | null;
   fecha?: string | null;
+  mes_actualizacion?: string | null;
   precio?: number | null;
 };
 
@@ -45,6 +46,7 @@ type InternalItem = {
   cod_interno?: string | null;
   nom_interno?: string | null;
   fecha?: string | null;
+  mes_actualizacion?: string | null;
   precio?: number | null;
 };
 
@@ -72,6 +74,12 @@ function classHeader(active: boolean) {
 }
 const normalizeStr = (v: any) => String(v ?? '').toLowerCase().trim();
 const cmp = (a: any, b: any) => (a < b ? -1 : a > b ? 1 : 0);
+const formatMonthLabel = (value: unknown) => {
+  const normalized = formatYearMonth(value);
+  if (!normalized) return '—';
+  const [year, month] = normalized.split('-');
+  return `${month}/${year}`;
+};
 
 /* ---------- Input de búsqueda ---------- */
 const SearchInput: React.FC<{ value: string; onChange: (v: string) => void; placeholder: string; }> =
@@ -284,9 +292,10 @@ export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen
     const sorted = [...filtered].sort((a, b) => {
       const av: any = a[sortExtKey];
       const bv: any = b[sortExtKey];
-      const r = sortExtKey === 'fecha'
-        ? compareYMD(av, bv)
-        : cmp(normalizeStr(av), normalizeStr(bv));
+      let r: number;
+      if (sortExtKey === 'fecha') r = compareYMD(av, bv);
+      else if (sortExtKey === 'mes_actualizacion') r = compareYearMonth(av, bv);
+      else r = cmp(normalizeStr(av), normalizeStr(bv));
       return sortExtDir === 'asc' ? r : -r;
     });
     return sorted;
@@ -298,9 +307,10 @@ export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen
     const sorted = [...filtered].sort((a, b) => {
       const av: any = a[sortIntKey];
       const bv: any = b[sortIntKey];
-      const r = sortIntKey === 'fecha'
-        ? compareYMD(av, bv)
-        : cmp(normalizeStr(av), normalizeStr(bv));
+      let r: number;
+      if (sortIntKey === 'fecha') r = compareYMD(av, bv);
+      else if (sortIntKey === 'mes_actualizacion') r = compareYearMonth(av, bv);
+      else r = cmp(normalizeStr(av), normalizeStr(bv));
       return sortIntDir === 'asc' ? r : -r;
     });
     return sorted;
@@ -308,11 +318,11 @@ export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen
 
   const toggleSortExternal = (key: SortKeyExternal) => {
     if (sortExtKey === key) setSortExtDir(d => (d === 'asc' ? 'desc' : 'asc'));
-    else { setSortExtKey(key); setSortExtDir(key === 'fecha' ? 'desc' : 'asc'); }
+    else { setSortExtKey(key); setSortExtDir(key === 'fecha' || key === 'mes_actualizacion' ? 'desc' : 'asc'); }
   };
   const toggleSortInternal = (key: SortKeyInternal) => {
     if (sortIntKey === key) setSortIntDir(d => (d === 'asc' ? 'desc' : 'asc'));
-    else { setSortIntKey(key); setSortIntDir(key === 'fecha' ? 'desc' : 'asc'); }
+    else { setSortIntKey(key); setSortIntDir(key === 'fecha' || key === 'mes_actualizacion' ? 'desc' : 'asc'); }
   };
 
   /* ---------- Selecciones ---------- */
@@ -538,11 +548,14 @@ export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen
                       <th className={classHeader(sortExtKey === 'fecha')} onClick={() => toggleSortExternal('fecha')}>
                         Fecha ingreso {sortExtKey === 'fecha' ? sortIcon(sortExtDir) : sortIcon()}
                       </th>
+                      <th className={classHeader(sortExtKey === 'mes_actualizacion')} onClick={() => toggleSortExternal('mes_actualizacion')}>
+                        Mes actualización {sortExtKey === 'mes_actualizacion' ? sortIcon(sortExtDir) : sortIcon()}
+                      </th>
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-gray-200 dark:divide-white/10 bg-white/80 dark:bg-transparent">
                     {filteredSortedExternals.length === 0 ? (
-                      <tr><td colSpan={3} className="px-6 py-4 text-center text-gray-500 dark:text-gray-300">{externals.length === 0 ? 'No hay productos no relacionados.' : 'Sin coincidencias.'}</td></tr>
+                      <tr><td colSpan={4} className="px-6 py-4 text-center text-gray-500 dark:text-gray-300">{externals.length === 0 ? 'No hay productos no relacionados.' : 'Sin coincidencias.'}</td></tr>
                     ) : filteredSortedExternals.map(item => {
                       const linkSel = selectedExternals.some(e => e.id_externo === item.id_externo);
                       const delSel = extDeleteIds.has(item.id_externo);
@@ -555,6 +568,7 @@ export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen
                           <td className="px-6 py-4 text-gray-900 dark:text-gray-100">{item.nom_externo ?? ''}</td>
                           <td className="px-6 py-4 text-gray-900 dark:text-gray-100">{item.proveedor ?? 'Sin proveedor'}</td>
                           <td className="px-6 py-4 text-gray-700 dark:text-gray-300">{formatYMD(item.fecha)}</td>
+                          <td className="px-6 py-4 text-gray-700 dark:text-gray-300">{formatMonthLabel(item.mes_actualizacion)}</td>
                         </tr>
                       );
                     })}
@@ -598,12 +612,15 @@ export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen
                       <th className={classHeader(sortIntKey === 'fecha')} onClick={() => toggleSortInternal('fecha')}>
                         Fecha ingreso {sortIntKey === 'fecha' ? sortIcon(sortIntDir) : sortIcon()}
                       </th>
+                      <th className={classHeader(sortIntKey === 'mes_actualizacion')} onClick={() => toggleSortInternal('mes_actualizacion')}>
+                        Mes actualización {sortIntKey === 'mes_actualizacion' ? sortIcon(sortIntDir) : sortIcon()}
+                      </th>
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-gray-200 dark:divide-white/10 bg-white/80 dark:bg-transparent">
                     {filteredSortedInternals.length === 0 ? (
                       <tr>
-                        <td colSpan={2} className="px-6 py-4 text-center text-gray-500 dark:text-gray-300">
+                        <td colSpan={3} className="px-6 py-4 text-center text-gray-500 dark:text-gray-300">
                           {internals.length === 0 ? 'No hay productos no relacionados.' : 'Sin coincidencias.'}
                         </td>
                       </tr>
@@ -623,6 +640,9 @@ export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen
                           {/* Fecha */}
                           <td className="px-6 py-4 text-gray-700 dark:text-gray-300">
                             {formatYMD(item.fecha)}
+                          </td>
+                          <td className="px-6 py-4 text-gray-700 dark:text-gray-300">
+                            {formatMonthLabel(item.mes_actualizacion)}
                           </td>
                         </tr>
                       );

--- a/project/src/utils/date.ts
+++ b/project/src/utils/date.ts
@@ -19,6 +19,31 @@ export function formatYMD(value: unknown, fallback = ''): string {
   return normalized ?? fallback;
 }
 
+export function normalizeToYearMonth(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === 'string') {
+    const match = value.match(/^(\d{4})-(\d{2})/);
+    if (match) {
+      return `${match[1]}-${match[2]}`;
+    }
+  }
+  const ymd = normalizeToYMD(value);
+  if (ymd) return ymd.slice(0, 7);
+  return null;
+}
+
+export function formatYearMonth(value: unknown, fallback = ''): string {
+  const normalized = normalizeToYearMonth(value);
+  return normalized ?? fallback;
+}
+
+export function compareYearMonth(a: unknown, b: unknown): number {
+  const normalizedA = normalizeToYearMonth(a) ?? '';
+  const normalizedB = normalizeToYearMonth(b) ?? '';
+  if (normalizedA === normalizedB) return 0;
+  return normalizedA < normalizedB ? -1 : 1;
+}
+
 export function compareYMD(a: unknown, b: unknown): number {
   const normalizedA = normalizeToYMD(a) ?? '';
   const normalizedB = normalizeToYMD(b) ?? '';


### PR DESCRIPTION
## Summary
- update manual product creation to reuse existing records by code or name, refreshing price and month metadata while keeping automatic linking
- extend XLSX imports to upsert products with month tracking, avoiding duplicates for both Gampack and supplier lists
- add schema support and UI columns to surface the last update month for unlinked products

## Testing
- npm test *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68fa19191834832d91f7d553ce2ea835