### PR TITLE
Add unmatched Gampack visibility and provider navigation fixes

### DIFF
--- a/project/server/index.js
+++ b/project/server/index.js
@@ -855,6 +855,7 @@ function createNoRelacionadosHandler(tipo) {
         const sql = `
           SELECT DISTINCT
             lp.id_externo AS id_externo,
+            lp.cod_externo AS cod_externo,
             lp.cod_externo AS codigo,
             lp.nom_externo AS nom_externo,
             lp.proveedor AS proveedor,
@@ -896,6 +897,7 @@ function createNoRelacionadosHandler(tipo) {
       const sql = `
         SELECT DISTINCT
           li.id_interno AS id_interno,
+          li.cod_interno AS cod_interno,
           li.cod_interno AS codigo,
           li.nom_interno AS nom_interno,
           li.precio_final AS precio_final,

--- a/project/src/routes/RoleRouter.tsx
+++ b/project/src/routes/RoleRouter.tsx
@@ -9,6 +9,7 @@ import VentaCompare from "../screens/venta/CompareScreen";
 import VentaManual from "../screens/venta/ManualEntryScreen";
 import VentaMainEq from "../screens/venta/MainEquivalences";
 import VentaUnmatched from "../screens/venta/UnmatchedEquivalencesScreen";
+import VentaActiveSuppliers from "../screens/venta/ActiveSuppliersScreen";
 
 // COMPRA (por ahora alias a venta)
 import CompraHome from "../screens/compra/HomeScreen";
@@ -16,10 +17,11 @@ import CompraCompare from "../screens/compra/CompareScreen";
 import CompraManual from "../screens/compra/ManualEntryScreen";
 import CompraMainEq from "../screens/compra/MainEquivalences";
 import CompraUnmatched from "../screens/compra/UnmatchedEquivalencesScreen";
+import CompraActiveSuppliers from "../screens/venta/ActiveSuppliersScreen";
 
 // Si ya tenés este tipo en otro archivo, podés importarlo.
 // Lo defino acá para que compile sin depender de otros imports.
-type Screen = "home" | "compare" | "manual" | "equivalences" | "unmatched";
+type Screen = "home" | "compare" | "manual" | "equivalences" | "unmatched" | "providers";
 
 function pathFor(base: "/venta" | "/compra", screen: Screen) {
   switch (screen) {
@@ -28,6 +30,7 @@ function pathFor(base: "/venta" | "/compra", screen: Screen) {
     case "manual":        return `${base}/manual`;
     case "equivalences":  return `${base}/equivalences`;
     case "unmatched":     return `${base}/unmatched`;
+    case "providers":     return `${base}/providers`;
   }
 }
 
@@ -83,6 +86,14 @@ export default function RoleRouter() {
           </RequireRole>
         }
       />
+      <Route
+        path="/venta/providers"
+        element={
+          <RequireRole allow="venta">
+            <VentaActiveSuppliers onNavigate={goVenta} />
+          </RequireRole>
+        }
+      />
 
       {/* COMPRA */}
       <Route
@@ -122,6 +133,14 @@ export default function RoleRouter() {
         element={
           <RequireRole allow="compra">
             <CompraUnmatched onNavigate={goCompra} />
+          </RequireRole>
+        }
+      />
+      <Route
+        path="/compra/providers"
+        element={
+          <RequireRole allow="compra">
+            <CompraActiveSuppliers onNavigate={goCompra} />
           </RequireRole>
         }
       />

--- a/project/src/screens/venta/CalculadoraVentaScreen.tsx
+++ b/project/src/screens/venta/CalculadoraVentaScreen.tsx
@@ -4,6 +4,7 @@ import ManualEntryScreen from './ManualEntryScreen';
 import CompareScreen from './CompareScreen';
 import MainEquivalences from './MainEquivalences';
 import UnmatchedEquivalencesScreen from './UnmatchedEquivalencesScreen';
+import ActiveSuppliersScreen from './ActiveSuppliersScreen';
 
 const SCREENS = {
   home: HomeScreen,
@@ -11,6 +12,7 @@ const SCREENS = {
   compare: CompareScreen,
   equivalences: MainEquivalences,
   unmatched: UnmatchedEquivalencesScreen,
+  providers: ActiveSuppliersScreen,
 } as const;
 
 type ScreenKey = keyof typeof SCREENS;

--- a/project/src/screens/venta/EquivalencesScreen.tsx
+++ b/project/src/screens/venta/EquivalencesScreen.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { Input } from '../../components/Input';
 import { Table, Column } from '../../components/Table';
 import { ProductEquivalence } from '../../tipos/database';
 import { Search, ArrowLeft, ArrowUp, Pencil, Save, X } from 'lucide-react';
 import { Screen } from '../../types';
 import { apiFetch } from '../../lib/api';
-import { normalizeToYMD } from '../../utils/date';
+import { normalizeToYMD, formatYearMonth } from '../../utils/date';
 
 interface EquivalencesScreenProps {
   onNavigate: (screen: Screen) => void;
@@ -13,6 +13,21 @@ interface EquivalencesScreenProps {
 
 // Utilidad para formatear fecha a yyyy-MM-dd para <input type="date">
 const toDateInput = (value: unknown) => normalizeToYMD(value) ?? '';
+
+interface UnmatchedInternal {
+  id_interno: number;
+  cod_interno?: string | null;
+  nom_interno?: string | null;
+  fecha?: string | null;
+  mes_actualizacion?: string | null;
+}
+
+const formatMonthLabel = (value: unknown) => {
+  const normalized = formatYearMonth(value);
+  if (!normalized) return '—';
+  const [year, month] = normalized.split('-');
+  return `${month}/${year}`;
+};
 
 export const EquivalencesScreen: React.FC<EquivalencesScreenProps> = ({ onNavigate }) => {
   const [equivalences, setEquivalences] = useState<ProductEquivalence[]>([]);
@@ -26,6 +41,11 @@ export const EquivalencesScreen: React.FC<EquivalencesScreenProps> = ({ onNaviga
   // Botón “Top”
   const [showBackToTop, setShowBackToTop] = useState(false);
 
+  // Productos Gampack sin relación
+  const [unmatchedInternals, setUnmatchedInternals] = useState<UnmatchedInternal[]>([]);
+  const [loadingUnmatched, setLoadingUnmatched] = useState(false);
+  const [unmatchedError, setUnmatchedError] = useState<string | null>(null);
+
   // Edición
   const [editOpen, setEditOpen] = useState(false);
   const [editRow, setEditRow] = useState<ProductEquivalence | null>(null);
@@ -38,6 +58,34 @@ export const EquivalencesScreen: React.FC<EquivalencesScreenProps> = ({ onNaviga
 
   const searchInputId = 'equiv-search-input';
   const topAnchorRef = useRef<HTMLDivElement>(null);
+
+  const fetchUnmatchedInternals = useCallback(async () => {
+    setLoadingUnmatched(true);
+    setUnmatchedError(null);
+    try {
+      const res = await apiFetch('/api/no-relacionados/gampack?limit=500');
+      if (!res.ok) throw new Error('Error al obtener productos Gampack no relacionados');
+      const data = await res.json();
+      const normalized: UnmatchedInternal[] = Array.isArray(data)
+        ? data
+            .map((item: any) => ({
+              id_interno: Number(item?.id_interno ?? item?.id ?? 0),
+              cod_interno: item?.cod_interno ?? item?.codigo ?? null,
+              nom_interno: item?.nom_interno ?? item?.nombre ?? null,
+              fecha: item?.fecha ?? null,
+              mes_actualizacion: item?.mes_actualizacion ?? null,
+            }))
+            .filter((item) => Number.isFinite(item.id_interno) && item.id_interno > 0)
+        : [];
+      setUnmatchedInternals(normalized);
+    } catch (error) {
+      console.error('Error fetching unmatched Gampack:', error);
+      setUnmatchedInternals([]);
+      setUnmatchedError('No se pudieron cargar los productos Gampack no relacionados.');
+    } finally {
+      setLoadingUnmatched(false);
+    }
+  }, []);
 
   const fetchEquivalences = async (search: string) => {
     setLoading(true);
@@ -54,7 +102,10 @@ export const EquivalencesScreen: React.FC<EquivalencesScreenProps> = ({ onNaviga
     }
   };
 
-  useEffect(() => { fetchEquivalences(''); }, []);
+  useEffect(() => {
+    fetchEquivalences('');
+    fetchUnmatchedInternals();
+  }, [fetchUnmatchedInternals]);
   useEffect(() => {
     const timeout = setTimeout(() => { fetchEquivalences(searchTerm.trim()); }, 300);
     return () => clearTimeout(timeout);
@@ -139,6 +190,7 @@ export const EquivalencesScreen: React.FC<EquivalencesScreenProps> = ({ onNaviga
       const data = await res.json();
       if (data?.success) {
         setEquivalences((prev) => prev.filter((eq) => (eq as any).id !== id));
+        fetchUnmatchedInternals();
         showToast('🗑️ Relación eliminada');
       } else {
         alert('Error eliminando relación');
@@ -238,6 +290,7 @@ export const EquivalencesScreen: React.FC<EquivalencesScreenProps> = ({ onNaviga
       );
 
       showToast('✅ Relación actualizada');
+      fetchUnmatchedInternals();
       closeEdit();
     } catch (err: any) {
       console.error('❌ Error actualizando relación:', err);
@@ -260,6 +313,16 @@ export const EquivalencesScreen: React.FC<EquivalencesScreenProps> = ({ onNaviga
       return byCriteria && values.some((v) => v.includes(q));
     });
   };
+
+  const filteredUnmatchedInternals = useMemo(() => {
+    const q = searchTerm.trim().toLowerCase();
+    if (!q) return unmatchedInternals;
+    return unmatchedInternals.filter((item) => {
+      const name = (item.nom_interno ?? '').toLowerCase();
+      const code = (item.cod_interno ?? '').toLowerCase();
+      return name.includes(q) || code.includes(q);
+    });
+  }, [searchTerm, unmatchedInternals]);
 
   const columns: Column<ProductEquivalence>[] = [
     { key: 'supplier', label: 'Proveedor Externo', sortable: true },
@@ -375,6 +438,85 @@ export const EquivalencesScreen: React.FC<EquivalencesScreenProps> = ({ onNaviga
             )}
           </div>
         </div>
+
+        <section className="mt-10">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Productos Gampack sin relación</h2>
+              <p className="text-sm text-gray-600 dark:text-white/70 max-w-2xl">
+                Revisá rápidamente los artículos internos que todavía no tienen un proveedor asociado para crear nuevas
+                equivalencias.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                onClick={fetchUnmatchedInternals}
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-200 dark:border-white/10 px-3 py-1.5 text-sm text-gray-700 dark:text-white/80 hover:bg-gray-100 dark:hover:bg-white/10 transition"
+                disabled={loadingUnmatched}
+              >
+                {loadingUnmatched ? 'Actualizando…' : 'Actualizar lista'}
+              </button>
+              <button
+                onClick={() => onNavigate('unmatched')}
+                className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-500"
+              >
+                Gestionar equivalencias
+              </button>
+            </div>
+          </div>
+
+          {unmatchedError && (
+            <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-700/40 dark:bg-red-900/20 dark:text-red-200">
+              {unmatchedError}
+            </div>
+          )}
+
+          <div className="mt-4 overflow-x-auto rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-[#0e1526]">
+            {loadingUnmatched ? (
+              <div className="divide-y divide-gray-200 dark:divide-white/10">
+                {[...Array(4)].map((_, index) => (
+                  <div key={index} className="h-12 animate-pulse bg-gray-100/80 dark:bg-white/5" />
+                ))}
+              </div>
+            ) : filteredUnmatchedInternals.length === 0 ? (
+              <div className="px-4 py-6 text-center text-sm text-gray-600 dark:text-white/70">
+                {unmatchedInternals.length === 0
+                  ? 'No hay productos Gampack pendientes de relacionar.'
+                  : 'No se encontraron productos que coincidan con la búsqueda.'}
+              </div>
+            ) : (
+              <table className="min-w-full divide-y divide-gray-200 dark:divide-white/10 text-sm">
+                <thead className="bg-gray-50 dark:bg-white/10 dark:text-white/90">
+                  <tr>
+                    <th className="px-4 py-3 text-left font-medium text-gray-600 dark:text-white/70">Nombre interno</th>
+                    <th className="px-4 py-3 text-left font-medium text-gray-600 dark:text-white/70">Código</th>
+                    <th className="px-4 py-3 text-left font-medium text-gray-600 dark:text-white/70">Fecha de alta</th>
+                    <th className="px-4 py-3 text-left font-medium text-gray-600 dark:text-white/70">Mes actualización</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200 dark:divide-white/10">
+                  {filteredUnmatchedInternals.map((item) => (
+                    <tr
+                      key={item.id_interno}
+                      className="bg-white/80 text-gray-900 transition hover:bg-gray-50 dark:bg-transparent dark:text-white/80 dark:hover:bg-white/10"
+                    >
+                      <td className="px-4 py-3">{item.nom_interno ?? 'Sin nombre'}</td>
+                      <td className="px-4 py-3 text-gray-600 dark:text-white/60">{item.cod_interno ?? '—'}</td>
+                      <td className="px-4 py-3 text-gray-600 dark:text-white/60">{normalizeToYMD(item.fecha) ?? '—'}</td>
+                      <td className="px-4 py-3 text-gray-600 dark:text-white/60">{formatMonthLabel(item.mes_actualizacion)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+
+          <div className="mt-2 text-xs text-gray-600 dark:text-white/60">
+            {loadingUnmatched
+              ? 'Cargando productos Gampack…'
+              : `${filteredUnmatchedInternals.length} producto${filteredUnmatchedInternals.length === 1 ? '' : 's'} visibles`}
+          </div>
+        </section>
       </div>
 
       {/* Botón flotante: volver al top */}

--- a/project/src/screens/venta/UnmatchedEquivalencesScreen.tsx
+++ b/project/src/screens/venta/UnmatchedEquivalencesScreen.tsx
@@ -143,8 +143,37 @@ export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen
   const [showTop, setShowTop] = useState(false);
 
   useEffect(() => {
-    apiFetch('/api/no-relacionados/proveedores').then(r => r.json()).then(d => setExternals(Array.isArray(d) ? d : [])).catch(() => setExternals([]));
-    apiFetch('/api/no-relacionados/gampack').then(r => r.json()).then(d => setInternals(Array.isArray(d) ? d : [])).catch(() => setInternals([]));
+    apiFetch('/api/no-relacionados/proveedores')
+      .then(r => r.json())
+      .then(d => {
+        if (!Array.isArray(d)) { setExternals([]); return; }
+        setExternals(
+          d
+            .map((item: any) => ({
+              ...item,
+              id_externo: Number(item?.id_externo ?? item?.id ?? 0),
+              cod_externo: item?.cod_externo ?? item?.codigo ?? null,
+            }))
+            .filter((item: any) => Number.isFinite(item.id_externo) && item.id_externo > 0)
+        );
+      })
+      .catch(() => setExternals([]));
+
+    apiFetch('/api/no-relacionados/gampack')
+      .then(r => r.json())
+      .then(d => {
+        if (!Array.isArray(d)) { setInternals([]); return; }
+        setInternals(
+          d
+            .map((item: any) => ({
+              ...item,
+              id_interno: Number(item?.id_interno ?? item?.id ?? 0),
+              cod_interno: item?.cod_interno ?? item?.codigo ?? null,
+            }))
+            .filter((item: any) => Number.isFinite(item.id_interno) && item.id_interno > 0)
+        );
+      })
+      .catch(() => setInternals([]));
   }, []);
 
   // accesos rápidos teclado


### PR DESCRIPTION
## Summary
- expose both `cod_externo` and `cod_interno` fields from the unmatched product queries so the frontend receives consistent identifiers
- surface a Gampack "sin relación" summary in the equivalences screen with refresh and navigation controls and normalise the unmatched payloads
- wire the active suppliers screen into the calculator and router so the card navigation opens the provider view correctly

## Testing
- npm run lint *(fails: existing TypeScript lint violations across legacy files)*

------
https://chatgpt.com/codex/tasks/task_b_68fb6e057284832d9acb4bdb60d06f7d