### PR TITLE
Allow multiple supplier links per Gampack product

### DIFF
--- a/project/server/index.js
+++ b/project/server/index.js
@@ -372,20 +372,6 @@ async function createRelationAndClean(db, idListaPrecios, idListaInterna, criter
     };
   }
 
-  const existingForInternal = await getDbRow(
-    db,
-    `SELECT id, id_lista_precios FROM relacion_articulos WHERE id_lista_interna = $1 LIMIT 1`,
-    [idListaInterna]
-  );
-  if (existingForInternal) {
-    return {
-      created: false,
-      reason: 'internal_already_related',
-      conflictingRelationId: existingForInternal.id,
-      conflictingExternalId: existingForInternal.id_lista_precios,
-    };
-  }
-
   const insertedRelation = await getDbRow(
     db,
     `INSERT INTO relacion_articulos (id_lista_precios, id_lista_interna, criterio_relacion)
@@ -1394,7 +1380,6 @@ app.post('/api/products', async (req, res) => {
 
       const motivo = (() => {
         if (!internalMatch?.row) return 'No se encontró coincidencia por código ni nombre';
-        if (relationResult?.reason === 'internal_already_related') return 'Coincidencia automática omitida: el producto interno ya está relacionado';
         if (relationResult?.reason === 'external_already_related') return 'Coincidencia automática omitida: el producto del proveedor ya está relacionado';
         return 'Usuario rechazó sugerencia de relación';
       })();
@@ -1449,7 +1434,6 @@ app.post('/api/products', async (req, res) => {
       if (!related) {
         const motivo = (() => {
           if (!externalMatch?.row) return 'No se encontró coincidencia por código ni nombre';
-          if (relationResult?.reason === 'internal_already_related') return 'Coincidencia automática omitida: el producto interno ya está relacionado';
           if (relationResult?.reason === 'external_already_related') return 'Coincidencia automática omitida: el producto del proveedor ya está relacionado';
           return 'Usuario rechazó sugerencia de relación';
         })();

--- a/project/server/schema.sql
+++ b/project/server/schema.sql
@@ -15,6 +15,18 @@ ON CONFLICT (username) DO NOTHING;
 
 SET search_path TO venta, public;
 
+DO $$
+DECLARE
+  schema_name TEXT;
+BEGIN
+  FOR schema_name IN SELECT unnest(ARRAY['venta', 'compra']) LOOP
+    EXECUTE format('ALTER TABLE IF EXISTS %I.relacion_articulos DROP CONSTRAINT IF EXISTS relacion_articulos_id_lista_interna_key', schema_name);
+    EXECUTE format('ALTER TABLE IF EXISTS %I.relacion_articulos DROP CONSTRAINT IF EXISTS relacion_articulos_id_lista_interna_idx', schema_name);
+    EXECUTE format('DROP INDEX IF EXISTS %I.relacion_articulos_id_lista_interna_idx', schema_name);
+    EXECUTE format('DROP INDEX IF EXISTS %I.relacion_articulos_id_lista_interna_key', schema_name);
+  END LOOP;
+END $$;
+
 CREATE TABLE IF NOT EXISTS lista_precios (
   id_externo BIGSERIAL PRIMARY KEY,
   nom_externo TEXT NOT NULL,
@@ -79,6 +91,7 @@ CREATE TABLE IF NOT EXISTS relacion_articulos (
   UNIQUE (id_lista_precios)
 );
 CREATE INDEX IF NOT EXISTS ix_rel_created_at ON relacion_articulos (created_at);
+CREATE INDEX IF NOT EXISTS ix_rel_id_lista_interna ON relacion_articulos (id_lista_interna);
 
 CREATE TABLE IF NOT EXISTS articulos_no_relacionados (
   id BIGSERIAL PRIMARY KEY,
@@ -209,6 +222,7 @@ CREATE TABLE IF NOT EXISTS relacion_articulos (
   UNIQUE (id_lista_precios)
 );
 CREATE INDEX IF NOT EXISTS ix_rel_created_at ON relacion_articulos (created_at);
+CREATE INDEX IF NOT EXISTS ix_rel_id_lista_interna ON relacion_articulos (id_lista_interna);
 
 CREATE TABLE IF NOT EXISTS articulos_no_relacionados (
   id BIGSERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- allow the relation helper to accept multiple external products for the same Gampack item while still enforcing uniqueness per supplier product
- update the schema to drop legacy unique constraints on id_lista_interna and add an index that supports the new lookup pattern across both tenants

## Testing
- DATABASE_URL=postgresql://localhost:5432/postgres npm test *(fails: API endpoints return 500 because no PostgreSQL database is available in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_690b40f67554832d833fe3ec3964cdda