### PR TITLE
feat: add alternate relations view to price comparison

### DIFF
--- a/project/server/index.js
+++ b/project/server/index.js
@@ -1297,19 +1297,71 @@ app.post('/api/check-product', async (req, res) => {
 app.get('/api/relaciones', async (req, res) => {
   try {
     const db = req.ctx.db;
-    const rows = await getDbRows(
-      db,
-      `SELECT r.*,
-              r.created_at AS relation_created_at,
-              lp.cod_externo, lp.nom_externo, 
-              li.cod_interno, li.nom_interno
-       FROM relacion_articulos r
-       LEFT JOIN lista_precios lp ON r.id_lista_precios = lp.id_externo
-       LEFT JOIN lista_interna li ON r.id_lista_interna = li.id_interno
-       ORDER BY r.created_at DESC`,
-      []
+
+    const collectIds = (raw) => {
+      if (!raw) return [];
+      const values = Array.isArray(raw) ? raw : [raw];
+      const ids = new Set();
+      values.forEach((value) => {
+        if (typeof value !== 'string') return;
+        value
+          .split(',')
+          .map((chunk) => Number.parseInt(chunk.trim(), 10))
+          .filter((num) => Number.isFinite(num) && num > 0)
+          .forEach((num) => ids.add(num));
+      });
+      return Array.from(ids);
+    };
+
+    const gampackIds = collectIds(req.query.gampack)
+      .concat(collectIds(req.query.id_lista_interna))
+      .concat(collectIds(req.query.idListaInterna));
+
+    const uniqueIds = Array.from(new Set(gampackIds));
+    const params = [];
+    let whereClause = '';
+
+    if (uniqueIds.length > 0) {
+      params.push(uniqueIds);
+      whereClause = 'WHERE r.id_lista_interna = ANY($1::bigint[])';
+    }
+
+    const sql = `
+      SELECT
+        r.id,
+        r.id_lista_precios,
+        r.id_lista_interna,
+        r.criterio_relacion,
+        r.created_at AS relation_created_at,
+        lp.id_externo,
+        lp.cod_externo,
+        lp.nom_externo,
+        lp.precio_final AS precio_externo,
+        lp.fecha AS fecha_externa,
+        lp.proveedor,
+        lp.mes_actualizacion AS proveedor_mes_actualizacion,
+        lp.familia AS proveedor_familia,
+        li.id_interno,
+        li.cod_interno,
+        li.nom_interno,
+        li.precio_final AS precio_interno,
+        li.fecha AS fecha_interna,
+        li.mes_actualizacion AS gampack_mes_actualizacion,
+        li.familia AS gampack_familia
+      FROM relacion_articulos r
+      LEFT JOIN lista_precios lp ON r.id_lista_precios = lp.id_externo
+      LEFT JOIN lista_interna li ON r.id_lista_interna = li.id_interno
+      ${whereClause}
+      ORDER BY
+        lp.proveedor ASC NULLS LAST,
+        lp.nom_externo ASC NULLS LAST,
+        r.created_at DESC
+    `;
+
+    const rows = await getDbRows(db, sql, params);
+    return res.json(
+      normalizeRowsDates(rows, ['fecha_externa', 'fecha_interna', 'relation_created_at'])
     );
-    res.json(rows);
   } catch (err) {
     console.error('Error al obtener relaciones:', err);
     return res.status(500).json({ error: 'Error al obtener relaciones' });

--- a/project/src/components/GampackRelationsView.tsx
+++ b/project/src/components/GampackRelationsView.tsx
@@ -1,0 +1,770 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Input } from './Input';
+import { Table, Column } from './Table';
+import { apiFetch } from '../lib/api';
+import { Loader2, ArrowUpDown, ChevronDown, ChevronUp, Filter } from 'lucide-react';
+
+type GampackProduct = {
+  id_interno: number;
+  cod_interno: string | null;
+  nom_interno: string | null;
+  precio_final: number | null;
+  fecha: string | null;
+  mes_actualizacion?: string | null;
+};
+
+type RawRelation = {
+  id: number;
+  id_lista_interna: number | null;
+  id_lista_precios: number | null;
+  criterio_relacion: string | null;
+  relation_created_at: string | null;
+  cod_externo: string | null;
+  nom_externo: string | null;
+  precio_externo: number | null;
+  fecha_externa: string | null;
+  proveedor: string | null;
+  cod_interno: string | null;
+  nom_interno: string | null;
+  precio_interno: number | null;
+  fecha_interna: string | null;
+};
+
+export type RelationRow = {
+  id: number;
+  supplier: string;
+  externalId: number | null;
+  externalCode: string;
+  externalName: string;
+  externalPrice: number | null;
+  externalDate: string | null;
+  gampackId: number | null;
+  gampackCode: string;
+  gampackName: string;
+  gampackPrice: number | null;
+  gampackDate: string | null;
+  relationCriteria: string;
+  relationCreatedAt: string | null;
+};
+
+const DEFAULT_COLUMN_KEYS: Array<keyof RelationRow> = [
+  'supplier',
+  'externalCode',
+  'externalName',
+  'externalPrice',
+  'externalDate',
+  'gampackCode',
+  'gampackName',
+  'gampackPrice',
+  'gampackDate',
+  'relationCriteria',
+];
+
+const DEFAULT_COLUMNS: Column<RelationRow>[] = [
+  {
+    key: 'supplier',
+    label: 'Proveedor',
+    sortable: true,
+  },
+  {
+    key: 'externalCode',
+    label: 'Código externo',
+    sortable: true,
+    render: (value: string) => value || '—',
+  },
+  {
+    key: 'externalName',
+    label: 'Producto proveedor',
+    sortable: true,
+    render: (value: string) => value || '—',
+  },
+  {
+    key: 'externalPrice',
+    label: 'Precio proveedor',
+    sortable: true,
+    align: 'right',
+    render: (value: number | null) =>
+      typeof value === 'number' ? `$${value.toFixed(2)}` : '—',
+  },
+  {
+    key: 'externalDate',
+    label: 'Actualización proveedor',
+    sortable: true,
+    render: (value: string | null) => value ?? '—',
+  },
+  {
+    key: 'gampackCode',
+    label: 'Código Gampack',
+    sortable: true,
+    render: (value: string) => value || '—',
+  },
+  {
+    key: 'gampackName',
+    label: 'Producto Gampack',
+    sortable: true,
+    render: (value: string) => value || '—',
+  },
+  {
+    key: 'gampackPrice',
+    label: 'Precio Gampack',
+    sortable: true,
+    align: 'right',
+    render: (value: number | null) =>
+      typeof value === 'number' ? `$${value.toFixed(2)}` : '—',
+  },
+  {
+    key: 'gampackDate',
+    label: 'Actualización Gampack',
+    sortable: true,
+    render: (value: string | null) => value ?? '—',
+  },
+  {
+    key: 'relationCriteria',
+    label: 'Criterio de relación',
+    sortable: true,
+    render: (value: string) => value || '—',
+  },
+];
+
+const columnConfigMap: Record<string, Column<RelationRow>> = DEFAULT_COLUMNS.reduce(
+  (acc, column) => {
+    acc[String(column.key)] = column;
+    return acc;
+  },
+  {} as Record<string, Column<RelationRow>>
+);
+
+const parseIdsFromQuery = (raw: unknown): number[] => {
+  if (!raw) return [];
+  const values = Array.isArray(raw) ? raw : [raw];
+  const ids = new Set<number>();
+  values.forEach((value) => {
+    if (typeof value !== 'string') return;
+    value
+      .split(',')
+      .map((chunk) => Number.parseInt(chunk.trim(), 10))
+      .filter((num) => Number.isFinite(num) && num > 0)
+      .forEach((num) => ids.add(num));
+  });
+  return Array.from(ids);
+};
+
+interface GampackRelationsViewProps {
+  className?: string;
+}
+
+export const GampackRelationsView: React.FC<GampackRelationsViewProps> = ({
+  className,
+}) => {
+  const [gampackItems, setGampackItems] = useState<GampackProduct[]>([]);
+  const [loadingGampack, setLoadingGampack] = useState(false);
+  const [gampackError, setGampackError] = useState<string | null>(null);
+  const [gampackSearch, setGampackSearch] = useState('');
+
+  const [selectedGampacks, setSelectedGampacks] = useState<number[]>([]);
+
+  const [relations, setRelations] = useState<RelationRow[]>([]);
+  const [loadingRelations, setLoadingRelations] = useState(false);
+  const [relationsError, setRelationsError] = useState<string | null>(null);
+
+  const [relationSearch, setRelationSearch] = useState('');
+  const [selectedProviders, setSelectedProviders] = useState<string[]>([]);
+
+  const [columnOrder, setColumnOrder] = useState<Array<keyof RelationRow>>(
+    DEFAULT_COLUMN_KEYS
+  );
+  const [sortKey, setSortKey] = useState<keyof RelationRow | ''>('');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+
+    const loadGampack = async () => {
+      setLoadingGampack(true);
+      setGampackError(null);
+      try {
+        const params = new URLSearchParams();
+        params.set('limit', '500');
+        if (gampackSearch.trim()) {
+          params.set('search', gampackSearch.trim());
+        }
+
+        const response = await apiFetch(`/api/gampack?${params.toString()}`, {
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error('No se pudieron cargar los productos Gampack.');
+        }
+        const data = await response.json();
+        if (cancelled) return;
+        setGampackItems(Array.isArray(data) ? data : []);
+      } catch (error) {
+        if (cancelled) return;
+        if ((error as any)?.name === 'AbortError') return;
+        console.error('Error fetching Gampack list', error);
+        setGampackError(
+          error instanceof Error
+            ? error.message
+            : 'Ocurrió un error al cargar los productos Gampack.'
+        );
+        setGampackItems([]);
+      } finally {
+        if (!cancelled) {
+          setLoadingGampack(false);
+        }
+      }
+    };
+
+    loadGampack();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [gampackSearch]);
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    const idsFromQuery = parseIdsFromQuery(searchParams.getAll('gampack'));
+    if (idsFromQuery.length > 0) {
+      setSelectedGampacks(idsFromQuery);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (selectedGampacks.length === 0) {
+      setRelations([]);
+      setSelectedProviders([]);
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+
+    const loadRelations = async () => {
+      setLoadingRelations(true);
+      setRelationsError(null);
+      try {
+        const params = new URLSearchParams();
+        selectedGampacks.forEach((id) => {
+          params.append('gampack', String(id));
+        });
+
+        const response = await apiFetch(`/api/relaciones?${params.toString()}`, {
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error('No se pudieron cargar las relaciones.');
+        }
+        const data = await response.json();
+        if (cancelled) return;
+        const parsed = Array.isArray(data)
+          ? buildRelationRows(data as RawRelation[])
+          : [];
+        setRelations(parsed);
+        setSelectedProviders((current) => {
+          const providers = new Set(
+            parsed.map((row) => row.supplier).filter((name) => !!name)
+          );
+          if (providers.size === 0) return [];
+          if (current.length === 0) return Array.from(providers);
+          return current.filter((name) => providers.has(name));
+        });
+      } catch (error) {
+        if (cancelled) return;
+        if ((error as any)?.name === 'AbortError') return;
+        console.error('Error fetching relations', error);
+        setRelations([]);
+        setRelationsError(
+          error instanceof Error
+            ? error.message
+            : 'Ocurrió un error al cargar las relaciones.'
+        );
+      } finally {
+        if (!cancelled) {
+          setLoadingRelations(false);
+        }
+      }
+    };
+
+    loadRelations();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [selectedGampacks]);
+
+  const providerOptions = useMemo(() => {
+    const providers = new Set<string>();
+    relations.forEach((relation) => {
+      if (relation.supplier) {
+        providers.add(relation.supplier);
+      }
+    });
+    return Array.from(providers).sort((a, b) => a.localeCompare(b, 'es'));
+  }, [relations]);
+
+  useEffect(() => {
+    if (providerOptions.length > 0 && selectedProviders.length === 0) {
+      setSelectedProviders(providerOptions);
+    }
+  }, [providerOptions, selectedProviders.length]);
+
+  const filteredRelations = useMemo(() => {
+    const search = relationSearch.trim().toLowerCase();
+    const allowedProviders = new Set(selectedProviders);
+
+    return relations.filter((relation) => {
+      if (allowedProviders.size > 0 && !allowedProviders.has(relation.supplier)) {
+        return false;
+      }
+
+      if (!search) return true;
+
+      const haystack = [
+        relation.externalCode,
+        relation.externalName,
+        relation.gampackCode,
+        relation.gampackName,
+        relation.supplier,
+      ]
+        .map((value) => value?.toString().toLowerCase() ?? '')
+        .join(' ');
+
+      return haystack.includes(search);
+    });
+  }, [relations, relationSearch, selectedProviders]);
+
+  const sortedRelations = useMemo(() => {
+    const rows = [...filteredRelations];
+    if (!sortKey) return rows;
+
+    const compare = (a: RelationRow, b: RelationRow) => {
+      const valueA = a[sortKey];
+      const valueB = b[sortKey];
+
+      if (valueA == null && valueB == null) return 0;
+      if (valueA == null) return -1;
+      if (valueB == null) return 1;
+
+      if (typeof valueA === 'number' && typeof valueB === 'number') {
+        return valueA - valueB;
+      }
+
+      const dateKeys: Array<keyof RelationRow> = [
+        'externalDate',
+        'gampackDate',
+        'relationCreatedAt',
+      ];
+      if (dateKeys.includes(sortKey)) {
+        const aTime = Date.parse(String(valueA));
+        const bTime = Date.parse(String(valueB));
+        if (Number.isNaN(aTime) && Number.isNaN(bTime)) return 0;
+        if (Number.isNaN(aTime)) return -1;
+        if (Number.isNaN(bTime)) return 1;
+        return aTime - bTime;
+      }
+
+      return String(valueA).localeCompare(String(valueB), 'es', {
+        sensitivity: 'base',
+        numeric: true,
+      });
+    };
+
+    rows.sort(compare);
+    if (sortDirection === 'desc') {
+      rows.reverse();
+    }
+    return rows;
+  }, [filteredRelations, sortDirection, sortKey]);
+
+  const orderedColumns = useMemo(() => {
+    return columnOrder
+      .map((key) => columnConfigMap[String(key)])
+      .filter((column): column is Column<RelationRow> => Boolean(column));
+  }, [columnOrder]);
+
+  const toggleGampackSelection = (id: number, checked: boolean) => {
+    setSelectedGampacks((current) => {
+      const selection = new Set(current);
+      if (checked) {
+        selection.add(id);
+      } else {
+        selection.delete(id);
+      }
+      return Array.from(selection);
+    });
+  };
+
+  const toggleProvider = (name: string, checked: boolean) => {
+    setSelectedProviders((current) => {
+      const set = new Set(current);
+      if (checked) {
+        set.add(name);
+      } else {
+        set.delete(name);
+      }
+      return Array.from(set);
+    });
+  };
+
+  const handleSort = (key: keyof RelationRow) => {
+    setSortDirection((current) =>
+      sortKey === key ? (current === 'asc' ? 'desc' : 'asc') : 'asc'
+    );
+    setSortKey(key);
+  };
+
+  const moveColumn = (key: keyof RelationRow, direction: 'up' | 'down') => {
+    setColumnOrder((current) => {
+      const index = current.indexOf(key);
+      if (index === -1) return current;
+      const next = [...current];
+      if (direction === 'up' && index > 0) {
+        [next[index - 1], next[index]] = [next[index], next[index - 1]];
+      } else if (direction === 'down' && index < current.length - 1) {
+        [next[index + 1], next[index]] = [next[index], next[index + 1]];
+      }
+      return next;
+    });
+  };
+
+  const resetColumns = () => setColumnOrder(DEFAULT_COLUMN_KEYS);
+
+  const gampackList = useMemo(() => {
+    const search = gampackSearch.trim().toLowerCase();
+    if (!search) return gampackItems;
+    return gampackItems.filter((item) => {
+      const composite = [item.cod_interno, item.nom_interno]
+        .map((value) => value?.toLowerCase() ?? '')
+        .join(' ');
+      return composite.includes(search);
+    });
+  }, [gampackItems, gampackSearch]);
+
+  const selectedCount = selectedGampacks.length;
+  const relationsCount = sortedRelations.length;
+
+  return (
+    <div className={['flex flex-col gap-4', className].filter(Boolean).join(' ')}>
+      <div className="flex flex-col gap-2 rounded-2xl border border-gray-200 bg-white/80 p-4 shadow-sm dark:border-white/10 dark:bg-white/5">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Relación de productos Gampack
+          </h2>
+          <p className="text-sm text-gray-600 dark:text-white/70">
+            {selectedCount > 0 || relationsCount > 0 ? (
+              <span>
+                {selectedCount}{' '}
+                {selectedCount === 1
+                  ? 'producto Gampack seleccionado'
+                  : 'productos Gampack seleccionados'}{' '}
+                — {relationsCount}{' '}
+                {relationsCount === 1
+                  ? 'producto relacionado encontrado'
+                  : 'productos relacionados encontrados'}
+              </span>
+            ) : (
+              'Seleccioná productos Gampack para ver las relaciones.'
+            )}
+          </p>
+        </div>
+        {relationsError && (
+          <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+            {relationsError}
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-4 lg:flex-row">
+        <section className="lg:w-5/12 xl:w-1/3">
+          <div className="flex h-full flex-col gap-3 rounded-2xl border border-gray-200 bg-white/90 p-4 shadow-sm dark:border-white/10 dark:bg-white/5">
+            <header className="flex items-center justify-between gap-2">
+              <div>
+                <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+                  Productos Gampack
+                </h3>
+                <p className="text-xs text-gray-500 dark:text-white/60">
+                  Seleccioná uno o más productos para ver los proveedores relacionados.
+                </p>
+              </div>
+              {loadingGampack && (
+                <Loader2 className="h-4 w-4 animate-spin text-gray-400 dark:text-white/60" />
+              )}
+            </header>
+
+            <Input
+              value={gampackSearch}
+              onChange={(event) => setGampackSearch(event.target.value)}
+              placeholder="Buscar por nombre o código"
+              className="dark:bg-white/10 dark:text-white dark:placeholder-white/60 dark:border-white/10 dark:focus:border-white/30 dark:focus:ring-white/20"
+            />
+
+            {gampackError && (
+              <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+                {gampackError}
+              </p>
+            )}
+
+            <div className="flex items-center justify-between text-xs text-gray-500 dark:text-white/60">
+              <span>{gampackList.length} resultados</span>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  className="rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition hover:border-blue-200 hover:text-blue-700 dark:border-white/10 dark:text-white/70 dark:hover:border-white/20 dark:hover:text-white"
+                  onClick={() => setSelectedGampacks(gampackList.map((item) => item.id_interno))}
+                  disabled={gampackList.length === 0}
+                >
+                  Seleccionar visibles
+                </button>
+                <button
+                  type="button"
+                  className="rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition hover:border-blue-200 hover:text-blue-700 dark:border-white/10 dark:text-white/70 dark:hover:border-white/20 dark:hover:text-white"
+                  onClick={() => setSelectedGampacks([])}
+                >
+                  Limpiar
+                </button>
+              </div>
+            </div>
+
+            <div className="flex-1 overflow-y-auto rounded-xl border border-gray-100 bg-white/70 dark:border-white/10 dark:bg-white/5" style={{ maxHeight: '420px' }}>
+              {gampackList.length === 0 && !loadingGampack ? (
+                <p className="px-4 py-6 text-sm text-gray-500 dark:text-white/60">
+                  No se encontraron productos con los filtros aplicados.
+                </p>
+              ) : (
+                <ul className="divide-y divide-gray-100 dark:divide-white/10">
+                  {gampackList.map((item) => {
+                    const id = item.id_interno;
+                    const checked = selectedGampacks.includes(id);
+                    return (
+                      <li
+                        key={id}
+                        className="flex items-start gap-3 px-4 py-3 text-sm text-gray-700 transition hover:bg-blue-50/60 dark:text-white/80 dark:hover:bg-white/10"
+                      >
+                        <input
+                          type="checkbox"
+                          className="mt-1 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-white/20 dark:bg-transparent"
+                          checked={checked}
+                          onChange={(event) => toggleGampackSelection(id, event.target.checked)}
+                        />
+                        <div className="flex flex-col">
+                          <span className="font-medium text-gray-900 dark:text-white">
+                            {item.nom_interno ?? 'Sin nombre'}
+                          </span>
+                          <span className="text-xs text-gray-500 dark:text-white/60">
+                            Código: {item.cod_interno ?? '—'}
+                          </span>
+                          {item.precio_final != null && (
+                            <span className="text-xs text-gray-500 dark:text-white/60">
+                              Precio final: ${Number(item.precio_final).toFixed(2)}
+                            </span>
+                          )}
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className="flex-1">
+          <div className="flex h-full flex-col gap-4 rounded-2xl border border-gray-200 bg-white/90 p-4 shadow-sm dark:border-white/10 dark:bg-white/5">
+            <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div className="flex flex-col gap-1">
+                <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+                  Productos relacionados
+                </h3>
+                <p className="text-xs text-gray-500 dark:text-white/60">
+                  Visualizá los productos externos vinculados a los Gampack seleccionados.
+                </p>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="flex items-center gap-1 text-xs text-gray-500 dark:text-white/60">
+                  <Filter className="h-3.5 w-3.5" />
+                  {selectedProviders.length} / {providerOptions.length} proveedores
+                </div>
+                <button
+                  type="button"
+                  onClick={resetColumns}
+                  className="inline-flex items-center gap-1 rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition hover:border-blue-200 hover:text-blue-700 dark:border-white/10 dark:text-white/70 dark:hover:border-white/20 dark:hover:text-white"
+                >
+                  <ArrowUpDown className="h-3.5 w-3.5" /> Reset columnas
+                </button>
+              </div>
+            </header>
+
+            <div className="grid gap-3 lg:grid-cols-2">
+              <Input
+                value={relationSearch}
+                onChange={(event) => setRelationSearch(event.target.value)}
+                placeholder="Filtrar por proveedor, código o nombre"
+                className="dark:bg-white/10 dark:text-white dark:placeholder-white/60 dark:border-white/10 dark:focus:border-white/30 dark:focus:ring-white/20"
+              />
+
+              <div className="rounded-xl border border-gray-100 bg-white/70 p-3 text-xs shadow-sm dark:border-white/10 dark:bg-white/5">
+                <p className="mb-2 font-semibold text-gray-700 dark:text-white/80">Filtrar por proveedor</p>
+                {providerOptions.length === 0 ? (
+                  <p className="text-gray-500 dark:text-white/60">
+                    No hay proveedores para la selección actual.
+                  </p>
+                ) : (
+                  <div className="flex max-h-40 flex-col gap-1 overflow-y-auto pr-1">
+                    {providerOptions.map((provider) => {
+                      const checked = selectedProviders.includes(provider);
+                      return (
+                        <label
+                          key={provider}
+                          className="flex items-center justify-between gap-2 rounded-lg px-2 py-1 text-gray-600 transition hover:bg-blue-50/60 dark:text-white/70 dark:hover:bg-white/10"
+                        >
+                          <span className="flex-1 text-xs font-medium text-gray-700 dark:text-white">
+                            {provider}
+                          </span>
+                          <input
+                            type="checkbox"
+                            className="h-3.5 w-3.5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-white/20 dark:bg-transparent"
+                            checked={checked}
+                            onChange={(event) => toggleProvider(provider, event.target.checked)}
+                          />
+                        </label>
+                      );
+                    })}
+                  </div>
+                )}
+                {providerOptions.length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      className="rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition hover:border-blue-200 hover:text-blue-700 dark:border-white/10 dark:text-white/70 dark:hover:border-white/20 dark:hover:text-white"
+                      onClick={() => setSelectedProviders(providerOptions)}
+                    >
+                      Todos
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition hover:border-blue-200 hover:text-blue-700 dark:border-white/10 dark:text-white/70 dark:hover:border-white/20 dark:hover:text-white"
+                      onClick={() => setSelectedProviders([])}
+                    >
+                      Ninguno
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-gray-100 bg-white/70 p-3 shadow-sm dark:border-white/10 dark:bg-white/5">
+              <p className="mb-2 text-xs font-semibold text-gray-700 dark:text-white/80">
+                Ordenar columnas
+              </p>
+              <div className="flex flex-col gap-2">
+                {columnOrder.map((columnKey) => {
+                  const column = columnConfigMap[String(columnKey)];
+                  if (!column) return null;
+                  return (
+                    <div
+                      key={String(columnKey)}
+                      className="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs text-gray-600 shadow-sm transition hover:border-blue-200 hover:text-blue-700 dark:border-white/10 dark:bg-white/10 dark:text-white/70 dark:hover:border-white/20 dark:hover:text-white"
+                    >
+                      <span className="font-medium">{column.label}</span>
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => moveColumn(columnKey, 'up')}
+                          className="rounded-full border border-gray-200 p-1 text-gray-500 transition hover:border-blue-200 hover:text-blue-600 dark:border-white/10 dark:text-white/60 dark:hover:border-white/20 dark:hover:text-white"
+                          aria-label={`Subir columna ${column.label}`}
+                        >
+                          <ChevronUp className="h-3.5 w-3.5" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => moveColumn(columnKey, 'down')}
+                          className="rounded-full border border-gray-200 p-1 text-gray-500 transition hover:border-blue-200 hover:text-blue-600 dark:border-white/10 dark:text-white/60 dark:hover:border-white/20 dark:hover:text-white"
+                          aria-label={`Bajar columna ${column.label}`}
+                        >
+                          <ChevronDown className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="flex-1">
+              {selectedGampacks.length === 0 ? (
+                <div className="flex h-full items-center justify-center rounded-2xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-white/20 dark:bg-white/5 dark:text-white/70">
+                  Seleccioná uno o más productos Gampack para ver sus relaciones.
+                </div>
+              ) : loadingRelations ? (
+                <div className="flex h-full items-center justify-center rounded-2xl border border-gray-200 bg-white/70 p-6 text-sm text-gray-500 shadow-inner dark:border-white/10 dark:bg-white/5 dark:text-white/70">
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Cargando relaciones...
+                </div>
+              ) : relations.length === 0 ? (
+                <div className="flex h-full items-center justify-center rounded-2xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-white/20 dark:bg-white/5 dark:text-white/70">
+                  No hay productos relacionados para la selección actual.
+                </div>
+              ) : (
+                <Table
+                  data={sortedRelations}
+                  columns={orderedColumns}
+                  onSort={handleSort}
+                  sortKey={sortKey || undefined}
+                  sortDirection={sortDirection}
+                  emptyMessage="No hay productos relacionados para la selección actual"
+                  className="h-full"
+                />
+              )}
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+function buildRelationRows(rows: RawRelation[]): RelationRow[] {
+  const seen = new Map<string, RelationRow>();
+
+  rows.forEach((row) => {
+    const supplier = (row.proveedor ?? '').trim() || 'Sin proveedor';
+    const externalCode = row.cod_externo ?? '';
+    const externalName = row.nom_externo ?? '';
+    const gampackCode = row.cod_interno ?? '';
+    const gampackName = row.nom_interno ?? '';
+
+    const key = [supplier, row.id_lista_precios ?? '', externalCode, externalName]
+      .map((value) => String(value ?? '').toLowerCase().trim())
+      .join('|');
+
+    if (seen.has(key)) {
+      return;
+    }
+
+    seen.set(key, {
+      id: row.id,
+      supplier,
+      externalId: row.id_lista_precios,
+      externalCode: externalCode || '—',
+      externalName: externalName || 'Sin nombre',
+      externalPrice: row.precio_externo ?? null,
+      externalDate: row.fecha_externa ?? null,
+      gampackId: row.id_lista_interna ?? null,
+      gampackCode: gampackCode || '—',
+      gampackName: gampackName || 'Sin nombre',
+      gampackPrice: row.precio_interno ?? null,
+      gampackDate: row.fecha_interna ?? null,
+      relationCriteria: row.criterio_relacion ?? '',
+      relationCreatedAt: row.relation_created_at ?? null,
+    });
+  });
+
+  return Array.from(seen.values()).sort((a, b) =>
+    a.supplier.localeCompare(b.supplier, 'es')
+  );
+}
+

--- a/project/src/screens/venta/CompareScreen.tsx
+++ b/project/src/screens/venta/CompareScreen.tsx
@@ -6,6 +6,7 @@ import { PriceComparison } from '../../tipos/database';
 import { Search, List, LayoutGrid, CalendarDays, XCircle, Loader2 } from 'lucide-react';
 import { Screen } from '../../types';
 import { apiFetch } from '../../lib/api';
+import { GampackRelationsView } from '../../components/GampackRelationsView';
 
 interface CompareScreenProps {
   onNavigate: (screen: Screen) => void;
@@ -22,6 +23,7 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [loading, setLoading] = useState(true);
   const [layout, setLayout] = useState<'table' | 'detailed'>('detailed');
+  const [isAlternateView, setIsAlternateView] = useState(false);
 
   // Filtros
   const [dateFrom, setDateFrom] = useState(''); // YYYY-MM-DD
@@ -152,12 +154,22 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
   }, []);
 
   useEffect(() => {
+    if (isAlternateView) return;
     const delay = setTimeout(() => {
       if (dateRangeInvalid) return;
       loadComparisons(searchTerm);
     }, 300);
     return () => clearTimeout(delay);
-  }, [searchTerm, dateFrom, dateTo, famGenSel, famEspSel, dateRangeInvalid, selectedProviders]);
+  }, [
+    searchTerm,
+    dateFrom,
+    dateTo,
+    famGenSel,
+    famEspSel,
+    dateRangeInvalid,
+    selectedProviders,
+    isAlternateView
+  ]);
 
   // Construye el valor que mandamos como `familia` al backend
   const buildFamiliaQuery = () => {
@@ -237,8 +249,8 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
     setSelectedProviders([]);
   };
 
-  const handleLayoutChange = () => {
-    setLayout((prev) => (prev === 'detailed' ? 'table' : 'detailed'));
+  const toggleAlternateView = () => {
+    setIsAlternateView((prev) => !prev);
   };
 
   // Helpers diferencia
@@ -311,8 +323,10 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
       <div className="max-w-7xl mx-auto">
         <Navigation onBack={() => onNavigate('home')} title="Comparar Gampacks" />
 
-        {/* Filtros */}
-        <div className="grid grid-cols-1 md:grid-cols-6 gap-4 mb-2">
+        {!isAlternateView && (
+          <>
+            {/* Filtros */}
+            <div className="grid grid-cols-1 md:grid-cols-6 gap-4 mb-2">
           <div className="md:col-span-2">
             <label className="block text-xs text-gray-600 dark:text-white/80 mb-1">Buscar</label>
             <div className="relative">
@@ -438,155 +452,198 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
           </div>
         )}
 
-        <div className="flex justify-between items-center mb-4">
-          <p className="text-sm text-gray-700 dark:text-white">
-            Total productos: <strong className="dark:text-white">{comparisons.length}</strong>
-            {(dateFrom || dateTo) && (
-              <span className="ml-2 text-gray-600 dark:text-white/70">
-                {dateFrom ? `Desde ${dateFrom}` : ''}{dateFrom && dateTo ? ' · ' : ''}{dateTo ? `Hasta ${dateTo}` : ''}
-              </span>
-            )}
-          </p>
+          </>
+        )}
 
-          {/* Botón Cambiar vista */}
-          <button
-            onClick={() => handleLayoutChange()}
-            aria-pressed={layout === 'table'}
-            className={[
-              'group inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition-all duration-200 shadow-sm ring-1',
-              'bg-white text-gray-900 ring-gray-200 hover:bg-gray-50 hover:ring-gray-300 active:bg-gray-100',
-              'dark:bg-white/10 dark:text-white dark:ring-white/15 dark:hover:bg-white/15 dark:hover:ring-white/20 dark:active:bg-white/20',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:focus-visible:ring-white dark:focus-visible:ring-offset-0',
-              'backdrop-blur supports-[backdrop-filter]:backdrop-blur',
-            ].join(' ')}
-            title="Cambiar vista"
-          >
-            <span className="inline-flex items-center">
-              {layout === 'detailed' ? (
-                <List size={18} className="transition-transform duration-200 group-active:scale-95" />
-              ) : (
-                <LayoutGrid size={18} className="transition-transform duration-200 group-active:scale-95" />
+        <div className="flex flex-col gap-3 mb-4 md:flex-row md:items-center md:justify-between">
+          {!isAlternateView ? (
+            <p className="text-sm text-gray-700 dark:text-white">
+              Total productos: <strong className="dark:text-white">{comparisons.length}</strong>
+              {(dateFrom || dateTo) && (
+                <span className="ml-2 text-gray-600 dark:text-white/70">
+                  {dateFrom ? `Desde ${dateFrom}` : ''}{dateFrom && dateTo ? ' · ' : ''}{dateTo ? `Hasta ${dateTo}` : ''}
+                </span>
               )}
-            </span>
-            <span className="transition-colors">Cambiar vista</span>
-          </button>
+            </p>
+          ) : (
+            <p className="text-sm text-gray-700 dark:text-white">
+              Explorá las relaciones entre productos Gampack y proveedores externos.
+            </p>
+          )}
+
+          <div className="flex flex-wrap items-center gap-2">
+            {!isAlternateView && (
+              <div className="inline-flex rounded-full border border-gray-200 bg-white p-1 text-sm shadow-sm dark:border-white/10 dark:bg-white/5">
+                <button
+                  type="button"
+                  onClick={() => setLayout('detailed')}
+                  className={[
+                    'inline-flex items-center gap-1 rounded-full px-3 py-1 font-medium transition',
+                    layout === 'detailed'
+                      ? 'bg-blue-600 text-white shadow-sm'
+                      : 'text-gray-600 hover:text-blue-600 dark:text-white/70 dark:hover:text-white'
+                  ].join(' ')}
+                >
+                  <LayoutGrid size={16} /> Tarjetas
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setLayout('table')}
+                  className={[
+                    'inline-flex items-center gap-1 rounded-full px-3 py-1 font-medium transition',
+                    layout === 'table'
+                      ? 'bg-blue-600 text-white shadow-sm'
+                      : 'text-gray-600 hover:text-blue-600 dark:text-white/70 dark:hover:text-white'
+                  ].join(' ')}
+                >
+                  <List size={16} /> Tabla
+                </button>
+              </div>
+            )}
+
+            <button
+              onClick={toggleAlternateView}
+              aria-pressed={isAlternateView}
+              className={[
+                'group inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition-all duration-200 shadow-sm ring-1',
+                'bg-white text-gray-900 ring-gray-200 hover:bg-gray-50 hover:ring-gray-300 active:bg-gray-100',
+                'dark:bg-white/10 dark:text-white dark:ring-white/15 dark:hover:bg-white/15 dark:hover:ring-white/20 dark:active:bg-white/20',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900 dark:focus-visible:ring-white dark:focus-visible:ring-offset-0',
+                'backdrop-blur supports-[backdrop-filter]:backdrop-blur',
+              ].join(' ')}
+              title="Cambiar vista"
+            >
+              <span className="inline-flex items-center">
+                {isAlternateView ? (
+                  <List size={18} className="transition-transform duration-200 group-active:scale-95" />
+                ) : (
+                  <LayoutGrid size={18} className="transition-transform duration-200 group-active:scale-95" />
+                )}
+              </span>
+              <span className="transition-colors">Cambiar vista</span>
+            </button>
+          </div>
         </div>
 
-        {layout === 'table' ? (
-          <Table
-            columns={[
-              { key: 'internalProduct', label: 'Producto Interno', sortable: true, render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
-              { key: 'externalProduct', label: 'Producto Proveedor', sortable: true, render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
-              { key: 'internalFinalPrice', label: 'Final Interno', sortable: true, render: (v: any) => <span className="dark:text-white">{typeof v === 'number' ? `$${v.toFixed(2)}` : '—'}</span> },
-              { key: 'externalFinalPrice', label: 'Final Proveedor', sortable: true, render: (v: any) => <span className="dark:text-white">{typeof v === 'number' ? `$${v.toFixed(2)}` : '—'}</span> },
-              { key: 'internalDate', label: 'Fecha Interna', render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
-              { key: 'externalDate', label: 'Fecha Proveedor', render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
-              { key: 'supplier', label: 'Proveedor', render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
-              {
-                key: 'priceDifference',
-                label: 'Diferencia',
-                render: (_v: any, row: any) => {
-                  const pct = getDifferencePct(row.internalFinalPrice as number | null, row.externalFinalPrice as number | null);
-                  const amt = getDifferenceAmt(row.internalFinalPrice as number | null, row.externalFinalPrice as number | null);
-                  if (pct == null || amt == null) return <span className="dark:text-white">N/A</span>;
-                  return (
-                    <span className="inline-flex items-center gap-2">
-                      <span className="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800 dark:bg-white/10 dark:text-white">{pct}%</span>
-                      <span className="text-sm text-gray-700 dark:text-white/80">{formatSignedMoney(amt)}</span>
-                    </span>
-                  );
+        {!isAlternateView ? (
+          layout === 'table' ? (
+            <Table
+              columns={[
+                { key: 'internalProduct', label: 'Producto Interno', sortable: true, render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
+                { key: 'externalProduct', label: 'Producto Proveedor', sortable: true, render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
+                { key: 'internalFinalPrice', label: 'Final Interno', sortable: true, render: (v: any) => <span className="dark:text-white">{typeof v === 'number' ? `$${v.toFixed(2)}` : '—'}</span> },
+                { key: 'externalFinalPrice', label: 'Final Proveedor', sortable: true, render: (v: any) => <span className="dark:text-white">{typeof v === 'number' ? `$${v.toFixed(2)}` : '—'}</span> },
+                { key: 'internalDate', label: 'Fecha Interna', render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
+                { key: 'externalDate', label: 'Fecha Proveedor', render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
+                { key: 'supplier', label: 'Proveedor', render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
+                {
+                  key: 'priceDifference',
+                  label: 'Diferencia',
+                  render: (_v: any, row: any) => {
+                    const pct = getDifferencePct(row.internalFinalPrice as number | null, row.externalFinalPrice as number | null);
+                    const amt = getDifferenceAmt(row.internalFinalPrice as number | null, row.externalFinalPrice as number | null);
+                    if (pct == null || amt == null) return <span className="dark:text-white">N/A</span>;
+                    return (
+                      <span className="inline-flex items-center gap-2">
+                        <span className="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800 dark:bg-white/10 dark:text-white">{pct}%</span>
+                        <span className="text-sm text-gray-700 dark:text-white/80">{formatSignedMoney(amt)}</span>
+                      </span>
+                    );
+                  },
                 },
-              },
-              {
-                key: 'conclusion',
-                label: 'Conclusión',
-                render: (_v: any, row: any) => {
-                  const internal = typeof row.internalFinalPrice === 'number' ? row.internalFinalPrice : null;
-                  const external = typeof row.externalFinalPrice === 'number' ? row.externalFinalPrice : null;
-                  const verdict = getVerdict(internal, external);
-                  return (
-                    <span
+                {
+                  key: 'conclusion',
+                  label: 'Conclusión',
+                  render: (_v: any, row: any) => {
+                    const internal = typeof row.internalFinalPrice === 'number' ? row.internalFinalPrice : null;
+                    const external = typeof row.externalFinalPrice === 'number' ? row.externalFinalPrice : null;
+                    const verdict = getVerdict(internal, external);
+                    return (
+                      <span
+                        className={[
+                          'inline-flex items-center px-2.5 py-1 rounded text-xs font-medium border',
+                          verdict.classes
+                        ].join(' ')}
+                      >
+                        {verdict.text}
+                      </span>
+                    );
+                  }
+                }
+              ]}
+              data={comparisons}
+            />
+          ) : (
+            <div className="grid grid-cols-1 gap-4">
+              {loading && <div className="text-sm text-gray-600 dark:text-white/70">Cargando...</div>}
+              {!loading && comparisons.map((item, i) => {
+                const internal = typeof item.internalFinalPrice === 'number' ? item.internalFinalPrice : null;
+                const external = typeof item.externalFinalPrice === 'number' ? item.externalFinalPrice : null;
+                const pct = getDifferencePct(internal, external);
+                const amt = getDifferenceAmt(internal, external);
+                const verdict = getVerdict(internal, external);
+
+                return (
+                  <div key={i} className="border rounded-xl p-4 shadow-sm bg-white dark:bg-white/5 border-gray-200 dark:border-white/10 hover:shadow-md transition duration-300">
+                    <div className="grid grid-cols-2 gap-4 text-xs text-gray-700 dark:text-white/80 mb-2">
+                      <div>
+                        <p className="text-gray-500 dark:text-white/60">Fecha Interna</p>
+                        <p className="font-medium dark:text-white">{item.internalDate ?? '—'}</p>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-gray-500 dark:text-white/60">Fecha Proveedor</p>
+                        <p className="font-medium dark:text-white">{item.externalDate ?? '—'}</p>
+                        <p className="text-gray-500 dark:text-white/60 mt-1">
+                          Proveedor: <span className="font-semibold text-gray-900 dark:text-white">{item.supplier ?? '—'}</span>
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-3 gap-4 items-end">
+                      <div>
+                        <p className="text-xs text-gray-500 dark:text-white/60">Producto Gampack</p>
+                        <p className="text-base font-semibold text-gray-900 dark:text-white">{item.internalProduct ?? '—'}</p>
+                        <p className="text-xs text-gray-500 dark:text-white/60 mt-1">Precio Interno</p>
+                        <p className="text-lg font-bold text-green-600">{internal != null ? `$${internal.toFixed(2)}` : '—'}</p>
+                      </div>
+                      <div className="text-center">
+                        <p className="text-xs text-gray-500 dark:text-white/60">Diferencia</p>
+                        {pct == null || amt == null ? (
+                          <p className="text-sm dark:text-white/80">N/A</p>
+                        ) : (
+                          <div className="inline-flex flex-col items-center gap-1">
+                            <span className="px-2 py-0.5 rounded text-sm font-semibold bg-gray-100 text-gray-800 dark:bg-white/10 dark:text-white">{pct}%</span>
+                            <span className="text-sm text-gray-700 dark:text-white/80">{formatSignedMoney(amt)}</span>
+                          </div>
+                        )}
+                      </div>
+                      <div className="text-right">
+                        <p className="text-xs text-gray-500 dark:text-white/60">Producto Proveedor</p>
+                        <p className="text-base font-semibold text-gray-900 dark:text-white">{item.externalProduct ?? '—'}</p>
+                        <p className="text-xs text-gray-500 dark:text-white/60 mt-1">Precio Externo</p>
+                        <p className="text-lg font-bold text-blue-600">{external != null ? `$${external.toFixed(2)}` : '—'}</p>
+                      </div>
+                    </div>
+
+                    {/* Veredicto textual */}
+                    <div
                       className={[
-                        'inline-flex items-center px-2.5 py-1 rounded text-xs font-medium border',
+                        'mt-3 px-3 py-2 rounded-lg border text-sm font-medium',
                         verdict.classes
                       ].join(' ')}
                     >
                       {verdict.text}
-                    </span>
-                  );
-                }
-              }
-            ]}
-            data={comparisons}
-          />
+                    </div>
+                  </div>
+                );
+              })}
+              {!loading && comparisons.length === 0 && (
+                <div className="text-sm text-gray-600 dark:text-white/70">No hay resultados para los filtros seleccionados.</div>
+              )}
+            </div>
+          )
         ) : (
-          <div className="grid grid-cols-1 gap-4">
-            {loading && <div className="text-sm text-gray-600 dark:text-white/70">Cargando...</div>}
-            {!loading && comparisons.map((item, i) => {
-              const internal = typeof item.internalFinalPrice === 'number' ? item.internalFinalPrice : null;
-              const external = typeof item.externalFinalPrice === 'number' ? item.externalFinalPrice : null;
-              const pct = getDifferencePct(internal, external);
-              const amt = getDifferenceAmt(internal, external);
-              const verdict = getVerdict(internal, external);
-
-              return (
-                <div key={i} className="border rounded-xl p-4 shadow-sm bg-white dark:bg-white/5 border-gray-200 dark:border-white/10 hover:shadow-md transition duration-300">
-                  <div className="grid grid-cols-2 gap-4 text-xs text-gray-700 dark:text-white/80 mb-2">
-                    <div>
-                      <p className="text-gray-500 dark:text-white/60">Fecha Interna</p>
-                      <p className="font-medium dark:text-white">{item.internalDate ?? '—'}</p>
-                    </div>
-                    <div className="text-right">
-                      <p className="text-gray-500 dark:text-white/60">Fecha Proveedor</p>
-                      <p className="font-medium dark:text-white">{item.externalDate ?? '—'}</p>
-                      <p className="text-gray-500 dark:text-white/60 mt-1">
-                        Proveedor: <span className="font-semibold text-gray-900 dark:text-white">{item.supplier ?? '—'}</span>
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="grid grid-cols-3 gap-4 items-end">
-                    <div>
-                      <p className="text-xs text-gray-500 dark:text-white/60">Producto Gampack</p>
-                      <p className="text-base font-semibold text-gray-900 dark:text-white">{item.internalProduct ?? '—'}</p>
-                      <p className="text-xs text-gray-500 dark:text-white/60 mt-1">Precio Interno</p>
-                      <p className="text-lg font-bold text-green-600">{internal != null ? `$${internal.toFixed(2)}` : '—'}</p>
-                    </div>
-                    <div className="text-center">
-                      <p className="text-xs text-gray-500 dark:text-white/60">Diferencia</p>
-                      {pct == null || amt == null ? (
-                        <p className="text-sm dark:text-white/80">N/A</p>
-                      ) : (
-                        <div className="inline-flex flex-col items-center gap-1">
-                          <span className="px-2 py-0.5 rounded text-sm font-semibold bg-gray-100 text-gray-800 dark:bg-white/10 dark:text-white">{pct}%</span>
-                          <span className="text-sm text-gray-700 dark:text-white/80">{formatSignedMoney(amt)}</span>
-                        </div>
-                      )}
-                    </div>
-                    <div className="text-right">
-                      <p className="text-xs text-gray-500 dark:text-white/60">Producto Proveedor</p>
-                      <p className="text-base font-semibold text-gray-900 dark:text-white">{item.externalProduct ?? '—'}</p>
-                      <p className="text-xs text-gray-500 dark:text-white/60 mt-1">Precio Externo</p>
-                      <p className="text-lg font-bold text-blue-600">{external != null ? `$${external.toFixed(2)}` : '—'}</p>
-                    </div>
-                  </div>
-
-                  {/* Veredicto textual */}
-                  <div
-                    className={[
-                      'mt-3 px-3 py-2 rounded-lg border text-sm font-medium',
-                      verdict.classes
-                    ].join(' ')}
-                  >
-                    {verdict.text}
-                  </div>
-                </div>
-              );
-            })}
-            {!loading && comparisons.length === 0 && (
-              <div className="text-sm text-gray-600 dark:text-white/70">No hay resultados para los filtros seleccionados.</div>
-            )}
-          </div>
+          <GampackRelationsView />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a GampackRelationsView split layout that lets users select multiple internal products, filter providers, and reorder relation columns
- update CompareScreen to toggle between the existing comparison layouts and the new relations view while keeping the original filters
- extend /api/relaciones to accept multiple Gampack ids and return detailed metadata for rendering related external products

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_690be907d7d4832d917d998618474330