### PR TITLE
Simplify Gampack comparison view

### DIFF
--- a/project/src/components/GampackRelationsView.tsx
+++ b/project/src/components/GampackRelationsView.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Input } from './Input';
-import { Table, Column } from './Table';
+import { Loader2, CheckCircle2 } from 'lucide-react';
+
 import { apiFetch } from '../lib/api';
-import { Loader2, ArrowUpDown, ChevronDown, ChevronUp, Filter } from 'lucide-react';
+import { Input } from './Input';
 
 type GampackProduct = {
   id_interno: number;
@@ -30,109 +30,31 @@ type RawRelation = {
   fecha_interna: string | null;
 };
 
-export type RelationRow = {
+type SimplifiedRelation = {
   id: number;
-  supplier: string;
-  externalId: number | null;
-  externalCode: string;
-  externalName: string;
-  externalPrice: number | null;
-  externalDate: string | null;
   gampackId: number | null;
-  gampackCode: string;
   gampackName: string;
+  gampackCode: string;
   gampackPrice: number | null;
   gampackDate: string | null;
-  relationCriteria: string;
-  relationCreatedAt: string | null;
+  supplier: string;
+  supplierProductName: string;
+  supplierProductCode: string;
+  supplierPrice: number | null;
+  supplierDate: string | null;
+  differencePct: number | null;
 };
 
-const DEFAULT_COLUMN_KEYS: Array<keyof RelationRow> = [
-  'supplier',
-  'externalCode',
-  'externalName',
-  'externalPrice',
-  'externalDate',
-  'gampackCode',
-  'gampackName',
-  'gampackPrice',
-  'gampackDate',
-  'relationCriteria',
-];
+type SelectedSummary = {
+  id: number;
+  name: string;
+  code: string;
+  price: number | null;
+};
 
-const DEFAULT_COLUMNS: Column<RelationRow>[] = [
-  {
-    key: 'supplier',
-    label: 'Proveedor',
-    sortable: true,
-  },
-  {
-    key: 'externalCode',
-    label: 'Código externo',
-    sortable: true,
-    render: (value: string) => value || '—',
-  },
-  {
-    key: 'externalName',
-    label: 'Producto proveedor',
-    sortable: true,
-    render: (value: string) => value || '—',
-  },
-  {
-    key: 'externalPrice',
-    label: 'Precio proveedor',
-    sortable: true,
-    align: 'right',
-    render: (value: number | null) =>
-      typeof value === 'number' ? `$${value.toFixed(2)}` : '—',
-  },
-  {
-    key: 'externalDate',
-    label: 'Actualización proveedor',
-    sortable: true,
-    render: (value: string | null) => value ?? '—',
-  },
-  {
-    key: 'gampackCode',
-    label: 'Código Gampack',
-    sortable: true,
-    render: (value: string) => value || '—',
-  },
-  {
-    key: 'gampackName',
-    label: 'Producto Gampack',
-    sortable: true,
-    render: (value: string) => value || '—',
-  },
-  {
-    key: 'gampackPrice',
-    label: 'Precio Gampack',
-    sortable: true,
-    align: 'right',
-    render: (value: number | null) =>
-      typeof value === 'number' ? `$${value.toFixed(2)}` : '—',
-  },
-  {
-    key: 'gampackDate',
-    label: 'Actualización Gampack',
-    sortable: true,
-    render: (value: string | null) => value ?? '—',
-  },
-  {
-    key: 'relationCriteria',
-    label: 'Criterio de relación',
-    sortable: true,
-    render: (value: string) => value || '—',
-  },
-];
-
-const columnConfigMap: Record<string, Column<RelationRow>> = DEFAULT_COLUMNS.reduce(
-  (acc, column) => {
-    acc[String(column.key)] = column;
-    return acc;
-  },
-  {} as Record<string, Column<RelationRow>>
-);
+interface SimplifiedComparisonViewProps {
+  className?: string;
+}
 
 const parseIdsFromQuery = (raw: unknown): number[] => {
   if (!raw) return [];
@@ -149,32 +71,87 @@ const parseIdsFromQuery = (raw: unknown): number[] => {
   return Array.from(ids);
 };
 
-interface GampackRelationsViewProps {
-  className?: string;
-}
+const formatCurrency = (value: number | null): string => {
+  if (value == null || Number.isNaN(value)) return '—';
+  return `$${value.toFixed(2)}`;
+};
 
-export const GampackRelationsView: React.FC<GampackRelationsViewProps> = ({
+const buildSimplifiedRelations = (rows: RawRelation[]): SimplifiedRelation[] => {
+  const seen = new Map<string, SimplifiedRelation>();
+
+  rows.forEach((row) => {
+    const supplier = (row.proveedor ?? '').trim() || 'Sin proveedor';
+    const externalCode = row.cod_externo ?? '';
+    const externalName = row.nom_externo ?? '';
+    const gampackCode = row.cod_interno ?? '';
+    const gampackName = row.nom_interno ?? '';
+    const gampackPrice = row.precio_interno ?? null;
+    const supplierPrice = row.precio_externo ?? null;
+
+    const key = [supplier, externalCode, externalName, gampackCode, gampackName]
+      .map((chunk) => chunk.toLowerCase().trim())
+      .join('|');
+
+    if (seen.has(key)) {
+      return;
+    }
+
+    const differencePct =
+      gampackPrice == null || supplierPrice == null || gampackPrice === 0
+        ? null
+        : ((supplierPrice - gampackPrice) / gampackPrice) * 100;
+
+    seen.set(key, {
+      id: row.id,
+      gampackId: row.id_lista_interna ?? null,
+      gampackName: gampackName || 'Sin nombre',
+      gampackCode: gampackCode || '—',
+      gampackPrice,
+      gampackDate: row.fecha_interna ?? null,
+      supplier,
+      supplierProductName: externalName || 'Sin nombre',
+      supplierProductCode: externalCode || '—',
+      supplierPrice,
+      supplierDate: row.fecha_externa ?? null,
+      differencePct,
+    });
+  });
+
+  return Array.from(seen.values()).sort((a, b) => a.supplier.localeCompare(b.supplier, 'es'));
+};
+
+const differenceColor = (difference: number | null): string => {
+  if (difference == null) return 'text-gray-400';
+  if (difference < 0) return 'text-green-400';
+  if (difference > 0) return 'text-red-400';
+  return 'text-gray-400';
+};
+
+const differenceLabel = (difference: number | null): string => {
+  if (difference == null) return 'Diferencia: sin datos ⚪';
+  const formatted = `${difference > 0 ? '+' : ''}${difference.toFixed(1)}%`;
+  if (difference < 0) {
+    return `Diferencia: ${formatted} 🟢`;
+  }
+  if (difference > 0) {
+    return `Diferencia: ${formatted} 🔴`;
+  }
+  return `Diferencia: ${formatted} ⚪`;
+};
+
+export const SimplifiedComparisonView: React.FC<SimplifiedComparisonViewProps> = ({
   className,
 }) => {
   const [gampackItems, setGampackItems] = useState<GampackProduct[]>([]);
+  const [gampackSearch, setGampackSearch] = useState('');
   const [loadingGampack, setLoadingGampack] = useState(false);
   const [gampackError, setGampackError] = useState<string | null>(null);
-  const [gampackSearch, setGampackSearch] = useState('');
 
-  const [selectedGampacks, setSelectedGampacks] = useState<number[]>([]);
+  const [selectedProducts, setSelectedProducts] = useState<number[]>([]);
 
-  const [relations, setRelations] = useState<RelationRow[]>([]);
+  const [relations, setRelations] = useState<SimplifiedRelation[]>([]);
   const [loadingRelations, setLoadingRelations] = useState(false);
   const [relationsError, setRelationsError] = useState<string | null>(null);
-
-  const [relationSearch, setRelationSearch] = useState('');
-  const [selectedProviders, setSelectedProviders] = useState<string[]>([]);
-
-  const [columnOrder, setColumnOrder] = useState<Array<keyof RelationRow>>(
-    DEFAULT_COLUMN_KEYS
-  );
-  const [sortKey, setSortKey] = useState<keyof RelationRow | ''>('');
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
 
   useEffect(() => {
     let cancelled = false;
@@ -198,7 +175,7 @@ export const GampackRelationsView: React.FC<GampackRelationsViewProps> = ({
         }
         const data = await response.json();
         if (cancelled) return;
-        setGampackItems(Array.isArray(data) ? data : []);
+        setGampackItems(Array.isArray(data) ? (data as GampackProduct[]) : []);
       } catch (error) {
         if (cancelled) return;
         if ((error as any)?.name === 'AbortError') return;
@@ -228,14 +205,14 @@ export const GampackRelationsView: React.FC<GampackRelationsViewProps> = ({
     const searchParams = new URLSearchParams(window.location.search);
     const idsFromQuery = parseIdsFromQuery(searchParams.getAll('gampack'));
     if (idsFromQuery.length > 0) {
-      setSelectedGampacks(idsFromQuery);
+      setSelectedProducts(idsFromQuery);
     }
   }, []);
 
   useEffect(() => {
-    if (selectedGampacks.length === 0) {
+    if (selectedProducts.length === 0) {
       setRelations([]);
-      setSelectedProviders([]);
+      setRelationsError(null);
       return;
     }
 
@@ -247,7 +224,7 @@ export const GampackRelationsView: React.FC<GampackRelationsViewProps> = ({
       setRelationsError(null);
       try {
         const params = new URLSearchParams();
-        selectedGampacks.forEach((id) => {
+        selectedProducts.forEach((id) => {
           params.append('gampack', String(id));
         });
 
@@ -260,17 +237,9 @@ export const GampackRelationsView: React.FC<GampackRelationsViewProps> = ({
         const data = await response.json();
         if (cancelled) return;
         const parsed = Array.isArray(data)
-          ? buildRelationRows(data as RawRelation[])
+          ? buildSimplifiedRelations(data as RawRelation[])
           : [];
         setRelations(parsed);
-        setSelectedProviders((current) => {
-          const providers = new Set(
-            parsed.map((row) => row.supplier).filter((name) => !!name)
-          );
-          if (providers.size === 0) return [];
-          if (current.length === 0) return Array.from(providers);
-          return current.filter((name) => providers.has(name));
-        });
       } catch (error) {
         if (cancelled) return;
         if ((error as any)?.name === 'AbortError') return;
@@ -294,477 +263,312 @@ export const GampackRelationsView: React.FC<GampackRelationsViewProps> = ({
       cancelled = true;
       controller.abort();
     };
-  }, [selectedGampacks]);
+  }, [selectedProducts]);
 
-  const providerOptions = useMemo(() => {
-    const providers = new Set<string>();
-    relations.forEach((relation) => {
-      if (relation.supplier) {
-        providers.add(relation.supplier);
-      }
-    });
-    return Array.from(providers).sort((a, b) => a.localeCompare(b, 'es'));
-  }, [relations]);
-
-  useEffect(() => {
-    if (providerOptions.length > 0 && selectedProviders.length === 0) {
-      setSelectedProviders(providerOptions);
-    }
-  }, [providerOptions, selectedProviders.length]);
-
-  const filteredRelations = useMemo(() => {
-    const search = relationSearch.trim().toLowerCase();
-    const allowedProviders = new Set(selectedProviders);
-
-    return relations.filter((relation) => {
-      if (allowedProviders.size > 0 && !allowedProviders.has(relation.supplier)) {
-        return false;
-      }
-
-      if (!search) return true;
-
-      const haystack = [
-        relation.externalCode,
-        relation.externalName,
-        relation.gampackCode,
-        relation.gampackName,
-        relation.supplier,
-      ]
+  const filteredGampackItems = useMemo(() => {
+    if (!gampackSearch.trim()) return gampackItems;
+    const search = gampackSearch.trim().toLowerCase();
+    return gampackItems.filter((item) => {
+      const haystack = [item.nom_interno, item.cod_interno]
         .map((value) => value?.toString().toLowerCase() ?? '')
         .join(' ');
-
       return haystack.includes(search);
-    });
-  }, [relations, relationSearch, selectedProviders]);
-
-  const sortedRelations = useMemo(() => {
-    const rows = [...filteredRelations];
-    if (!sortKey) return rows;
-
-    const compare = (a: RelationRow, b: RelationRow) => {
-      const valueA = a[sortKey];
-      const valueB = b[sortKey];
-
-      if (valueA == null && valueB == null) return 0;
-      if (valueA == null) return -1;
-      if (valueB == null) return 1;
-
-      if (typeof valueA === 'number' && typeof valueB === 'number') {
-        return valueA - valueB;
-      }
-
-      const dateKeys: Array<keyof RelationRow> = [
-        'externalDate',
-        'gampackDate',
-        'relationCreatedAt',
-      ];
-      if (dateKeys.includes(sortKey)) {
-        const aTime = Date.parse(String(valueA));
-        const bTime = Date.parse(String(valueB));
-        if (Number.isNaN(aTime) && Number.isNaN(bTime)) return 0;
-        if (Number.isNaN(aTime)) return -1;
-        if (Number.isNaN(bTime)) return 1;
-        return aTime - bTime;
-      }
-
-      return String(valueA).localeCompare(String(valueB), 'es', {
-        sensitivity: 'base',
-        numeric: true,
-      });
-    };
-
-    rows.sort(compare);
-    if (sortDirection === 'desc') {
-      rows.reverse();
-    }
-    return rows;
-  }, [filteredRelations, sortDirection, sortKey]);
-
-  const orderedColumns = useMemo(() => {
-    return columnOrder
-      .map((key) => columnConfigMap[String(key)])
-      .filter((column): column is Column<RelationRow> => Boolean(column));
-  }, [columnOrder]);
-
-  const toggleGampackSelection = (id: number, checked: boolean) => {
-    setSelectedGampacks((current) => {
-      const selection = new Set(current);
-      if (checked) {
-        selection.add(id);
-      } else {
-        selection.delete(id);
-      }
-      return Array.from(selection);
-    });
-  };
-
-  const toggleProvider = (name: string, checked: boolean) => {
-    setSelectedProviders((current) => {
-      const set = new Set(current);
-      if (checked) {
-        set.add(name);
-      } else {
-        set.delete(name);
-      }
-      return Array.from(set);
-    });
-  };
-
-  const handleSort = (key: keyof RelationRow) => {
-    setSortDirection((current) =>
-      sortKey === key ? (current === 'asc' ? 'desc' : 'asc') : 'asc'
-    );
-    setSortKey(key);
-  };
-
-  const moveColumn = (key: keyof RelationRow, direction: 'up' | 'down') => {
-    setColumnOrder((current) => {
-      const index = current.indexOf(key);
-      if (index === -1) return current;
-      const next = [...current];
-      if (direction === 'up' && index > 0) {
-        [next[index - 1], next[index]] = [next[index], next[index - 1]];
-      } else if (direction === 'down' && index < current.length - 1) {
-        [next[index + 1], next[index]] = [next[index], next[index + 1]];
-      }
-      return next;
-    });
-  };
-
-  const resetColumns = () => setColumnOrder(DEFAULT_COLUMN_KEYS);
-
-  const gampackList = useMemo(() => {
-    const search = gampackSearch.trim().toLowerCase();
-    if (!search) return gampackItems;
-    return gampackItems.filter((item) => {
-      const composite = [item.cod_interno, item.nom_interno]
-        .map((value) => value?.toLowerCase() ?? '')
-        .join(' ');
-      return composite.includes(search);
     });
   }, [gampackItems, gampackSearch]);
 
-  const selectedCount = selectedGampacks.length;
-  const relationsCount = sortedRelations.length;
+  const selectedDetails = useMemo<SelectedSummary[]>(() => {
+    const map = new Map(gampackItems.map((item) => [item.id_interno, item] as const));
+    return selectedProducts
+      .map((id) => {
+        const direct = map.get(id);
+        if (direct) {
+          return {
+            id,
+            name: direct.nom_interno ?? 'Sin nombre',
+            code: direct.cod_interno ?? '—',
+            price: direct.precio_final ?? null,
+          } satisfies SelectedSummary;
+        }
+
+        const fallback = relations.find((relation) => relation.gampackId === id);
+        if (fallback) {
+          return {
+            id,
+            name: fallback.gampackName || 'Sin nombre',
+            code: fallback.gampackCode || '—',
+            price: fallback.gampackPrice ?? null,
+          } satisfies SelectedSummary;
+        }
+
+        return {
+          id,
+          name: `Producto ${id}`,
+          code: '—',
+          price: null,
+        } satisfies SelectedSummary;
+      });
+  }, [gampackItems, relations, selectedProducts]);
+
+  const relationsByGampack = useMemo(() => {
+    const grouped = new Map<number | 'unknown', SimplifiedRelation[]>();
+    relations.forEach((relation) => {
+      const key = relation.gampackId ?? 'unknown';
+      const list = grouped.get(key) ?? [];
+      list.push(relation);
+      grouped.set(key, list);
+    });
+    return grouped;
+  }, [relations]);
+
+  const toggleProductSelection = (productId: number) => {
+    setSelectedProducts((current) =>
+      current.includes(productId)
+        ? current.filter((id) => id !== productId)
+        : [...current, productId]
+    );
+  };
+
+  const clearSelection = () => {
+    setSelectedProducts([]);
+  };
+
+  const baseClasses = ['grid grid-cols-1 gap-6 p-4 md:grid-cols-2', className]
+    .filter(Boolean)
+    .join(' ');
 
   return (
-    <div className={['flex flex-col gap-4', className].filter(Boolean).join(' ')}>
-      <div className="flex flex-col gap-2 rounded-2xl border border-gray-200 bg-white/80 p-4 shadow-sm dark:border-white/10 dark:bg-white/5">
-        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-            Relación de productos Gampack
-          </h2>
-          <p className="text-sm text-gray-600 dark:text-white/70">
-            {selectedCount > 0 || relationsCount > 0 ? (
-              <span>
-                {selectedCount}{' '}
-                {selectedCount === 1
-                  ? 'producto Gampack seleccionado'
-                  : 'productos Gampack seleccionados'}{' '}
-                — {relationsCount}{' '}
-                {relationsCount === 1
-                  ? 'producto relacionado encontrado'
-                  : 'productos relacionados encontrados'}
-              </span>
-            ) : (
-              'Seleccioná productos Gampack para ver las relaciones.'
-            )}
+    <div className={baseClasses}>
+      <section className="flex flex-col rounded-lg bg-gray-900/90 p-4 shadow-lg ring-1 ring-black/30">
+        <header className="mb-4">
+          <h2 className="text-lg font-semibold text-white">Productos Gampack</h2>
+          <p className="text-sm text-gray-400">
+            Seleccioná uno o varios productos para descubrir sus relaciones con proveedores.
           </p>
+        </header>
+
+        <div className="mb-4 flex flex-col gap-3">
+          <Input
+            value={gampackSearch}
+            onChange={(event) => setGampackSearch(event.target.value)}
+            placeholder="Buscar por nombre o código"
+            className="border-gray-700 bg-gray-950/40 text-gray-100 placeholder:text-gray-500 focus:border-green-400 focus:ring-green-400"
+          />
+
+          <div className="flex items-center justify-between text-xs text-gray-500">
+            <span>{loadingGampack ? 'Cargando productos…' : `${filteredGampackItems.length} resultados`}</span>
+            <button
+              type="button"
+              onClick={clearSelection}
+              className="rounded-full border border-gray-700 px-3 py-1 font-medium text-gray-300 transition hover:border-green-500 hover:text-white"
+            >
+              Limpiar selección
+            </button>
+          </div>
         </div>
+
+        {gampackError && (
+          <p className="mb-3 rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+            {gampackError}
+          </p>
+        )}
+
+        <div className="relative flex-1 overflow-hidden rounded-lg border border-gray-800">
+          {loadingGampack && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center bg-gray-900/70">
+              <Loader2 className="mr-2 h-5 w-5 animate-spin text-gray-200" />
+              <span className="text-sm text-gray-200">Cargando productos…</span>
+            </div>
+          )}
+
+          <ul className="max-h-[70vh] divide-y divide-gray-800 overflow-y-auto">
+            {filteredGampackItems.length === 0 && !loadingGampack ? (
+              <li className="px-4 py-6 text-center text-sm text-gray-500">
+                No encontramos resultados con ese criterio.
+              </li>
+            ) : (
+              filteredGampackItems.map((product) => {
+                const isSelected = selectedProducts.includes(product.id_interno);
+                return (
+                  <li
+                    key={product.id_interno}
+                    onClick={() => toggleProductSelection(product.id_interno)}
+                    className={[
+                      'cursor-pointer px-4 py-3 transition-all',
+                      'hover:bg-green-600/20',
+                      isSelected
+                        ? 'bg-green-600/30 text-white'
+                        : 'text-gray-200',
+                    ].join(' ')}
+                  >
+                    <div className="flex items-start justify-between">
+                      <div>
+                        <p className="font-semibold">{product.nom_interno ?? 'Sin nombre'}</p>
+                        <p className="text-xs text-gray-400">Código: {product.cod_interno ?? '—'}</p>
+                      </div>
+                      {isSelected && (
+                        <CheckCircle2 className="h-5 w-5 text-green-400" aria-hidden="true" />
+                      )}
+                    </div>
+                    {product.precio_final != null && (
+                      <p className="mt-2 text-sm text-gray-300">
+                        Precio final: {formatCurrency(product.precio_final)}
+                      </p>
+                    )}
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        </div>
+      </section>
+
+      <section className="flex flex-col rounded-lg bg-gray-900/90 p-4 shadow-lg ring-1 ring-black/30">
+        <header className="mb-4 flex flex-col gap-2">
+          <h2 className="text-lg font-semibold text-white">Productos relacionados</h2>
+          <p className="text-sm text-gray-400">
+            {selectedProducts.length === 0
+              ? 'Seleccioná uno o varios productos Gampack para ver sus relaciones.'
+              : 'Compará los precios de proveedores frente a los valores de Gampack.'}
+          </p>
+        </header>
+
         {relationsError && (
-          <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+          <p className="mb-3 rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
             {relationsError}
           </p>
         )}
-      </div>
 
-      <div className="flex flex-col gap-4 lg:flex-row">
-        <section className="lg:w-5/12 xl:w-1/3">
-          <div className="flex h-full flex-col gap-3 rounded-2xl border border-gray-200 bg-white/90 p-4 shadow-sm dark:border-white/10 dark:bg-white/5">
-            <header className="flex items-center justify-between gap-2">
-              <div>
-                <h3 className="text-base font-semibold text-gray-900 dark:text-white">
-                  Productos Gampack
-                </h3>
-                <p className="text-xs text-gray-500 dark:text-white/60">
-                  Seleccioná uno o más productos para ver los proveedores relacionados.
-                </p>
-              </div>
-              {loadingGampack && (
-                <Loader2 className="h-4 w-4 animate-spin text-gray-400 dark:text-white/60" />
-              )}
-            </header>
+        <div className="mb-4 flex flex-wrap gap-2">
+          {selectedDetails.length > 0 ? (
+            selectedDetails.map((product) => (
+              <span
+                key={product.id}
+                className="inline-flex items-center gap-2 rounded-full bg-green-600/20 px-3 py-1 text-xs font-medium text-green-200"
+              >
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                {product.name}
+              </span>
+            ))
+          ) : (
+            <span className="text-xs text-gray-500">
+              Aún no seleccionaste productos.
+            </span>
+          )}
+        </div>
 
-            <Input
-              value={gampackSearch}
-              onChange={(event) => setGampackSearch(event.target.value)}
-              placeholder="Buscar por nombre o código"
-              className="dark:bg-white/10 dark:text-white dark:placeholder-white/60 dark:border-white/10 dark:focus:border-white/30 dark:focus:ring-white/20"
-            />
+        {selectedProducts.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center rounded-lg border border-dashed border-gray-800 bg-gray-950/40 p-6 text-center text-sm text-gray-500">
+            Seleccioná uno o varios productos Gampack para ver sus relaciones.
+          </div>
+        ) : loadingRelations ? (
+          <div className="flex flex-1 items-center justify-center rounded-lg border border-gray-800 bg-gray-950/40 p-6 text-sm text-gray-400">
+            <Loader2 className="mr-2 h-5 w-5 animate-spin text-gray-200" /> Cargando relaciones…
+          </div>
+        ) : relations.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center rounded-lg border border-dashed border-gray-800 bg-gray-950/40 p-6 text-center text-sm text-gray-500">
+            No encontramos productos de proveedores relacionados con tu selección.
+          </div>
+        ) : (
+          <div className="flex-1 space-y-4 overflow-y-auto pr-1">
+            {selectedDetails.map((product) => {
+              const productRelations = relationsByGampack.get(product.id) ?? [];
 
-            {gampackError && (
-              <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
-                {gampackError}
-              </p>
-            )}
-
-            <div className="flex items-center justify-between text-xs text-gray-500 dark:text-white/60">
-              <span>{gampackList.length} resultados</span>
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  className="rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition hover:border-blue-200 hover:text-blue-700 dark:border-white/10 dark:text-white/70 dark:hover:border-white/20 dark:hover:text-white"
-                  onClick={() => setSelectedGampacks(gampackList.map((item) => item.id_interno))}
-                  disabled={gampackList.length === 0}
+              return (
+                <article
+                  key={product.id}
+                  className="rounded-xl border border-gray-800 bg-gray-950/30 p-4"
                 >
-                  Seleccionar visibles
-                </button>
-                <button
-                  type="button"
-                  className="rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition hover:border-blue-200 hover:text-blue-700 dark:border-white/10 dark:text-white/70 dark:hover:border-white/20 dark:hover:text-white"
-                  onClick={() => setSelectedGampacks([])}
-                >
-                  Limpiar
-                </button>
-              </div>
-            </div>
+                  <header className="mb-3 flex flex-col gap-1">
+                    <span className="text-xs uppercase tracking-wide text-gray-500">
+                      Producto Gampack
+                    </span>
+                    <h3 className="text-base font-semibold text-white">
+                      {product.name}
+                    </h3>
+                    <p className="text-xs text-gray-500">
+                      Código {product.code} · Precio {formatCurrency(product.price)}
+                    </p>
+                  </header>
 
-            <div className="flex-1 overflow-y-auto rounded-xl border border-gray-100 bg-white/70 dark:border-white/10 dark:bg-white/5" style={{ maxHeight: '420px' }}>
-              {gampackList.length === 0 && !loadingGampack ? (
-                <p className="px-4 py-6 text-sm text-gray-500 dark:text-white/60">
-                  No se encontraron productos con los filtros aplicados.
-                </p>
-              ) : (
-                <ul className="divide-y divide-gray-100 dark:divide-white/10">
-                  {gampackList.map((item) => {
-                    const id = item.id_interno;
-                    const checked = selectedGampacks.includes(id);
-                    return (
+                  {productRelations.length === 0 ? (
+                    <p className="rounded-lg border border-dashed border-gray-800 bg-gray-950/40 px-3 py-2 text-sm text-gray-500">
+                      No hay proveedores relacionados para este producto.
+                    </p>
+                  ) : (
+                    <ul className="space-y-3">
+                      {productRelations.map((relation) => (
+                        <li
+                          key={relation.id}
+                          className="rounded-lg border border-gray-800 bg-gray-900/60 p-3 transition hover:border-green-500/60"
+                        >
+                          <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                            <div>
+                              <p className="text-sm font-semibold text-white">
+                                {relation.supplier} · {relation.supplierProductName}
+                              </p>
+                              <p className="text-xs text-gray-500">
+                                Código {relation.supplierProductCode} · Actualización {relation.supplierDate ?? '—'}
+                              </p>
+                            </div>
+                            <div className="text-sm text-gray-300">
+                              <p>Proveedor: {formatCurrency(relation.supplierPrice)}</p>
+                              <p>Gampack: {formatCurrency(relation.gampackPrice)}</p>
+                            </div>
+                          </div>
+                          <p className={`mt-3 text-sm font-semibold ${differenceColor(relation.differencePct)}`}>
+                            {differenceLabel(relation.differencePct)}
+                          </p>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </article>
+              );
+            })}
+
+            {Array.from(relationsByGampack.entries())
+              .filter(([key]) => key === 'unknown')
+              .map(([, orphanRelations]) => (
+                <article key="unknown" className="rounded-xl border border-gray-800 bg-gray-950/30 p-4">
+                  <header className="mb-3">
+                    <h3 className="text-base font-semibold text-white">Relaciones sin producto interno</h3>
+                    <p className="text-xs text-gray-500">
+                      Estos registros no pudieron vincularse a un producto Gampack específico.
+                    </p>
+                  </header>
+                  <ul className="space-y-3">
+                    {orphanRelations.map((relation) => (
                       <li
-                        key={id}
-                        className="flex items-start gap-3 px-4 py-3 text-sm text-gray-700 transition hover:bg-blue-50/60 dark:text-white/80 dark:hover:bg-white/10"
+                        key={relation.id}
+                        className="rounded-lg border border-gray-800 bg-gray-900/60 p-3 transition hover:border-green-500/60"
                       >
-                        <input
-                          type="checkbox"
-                          className="mt-1 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-white/20 dark:bg-transparent"
-                          checked={checked}
-                          onChange={(event) => toggleGampackSelection(id, event.target.checked)}
-                        />
-                        <div className="flex flex-col">
-                          <span className="font-medium text-gray-900 dark:text-white">
-                            {item.nom_interno ?? 'Sin nombre'}
-                          </span>
-                          <span className="text-xs text-gray-500 dark:text-white/60">
-                            Código: {item.cod_interno ?? '—'}
-                          </span>
-                          {item.precio_final != null && (
-                            <span className="text-xs text-gray-500 dark:text-white/60">
-                              Precio final: ${Number(item.precio_final).toFixed(2)}
-                            </span>
-                          )}
+                        <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                          <div>
+                            <p className="text-sm font-semibold text-white">
+                              {relation.supplier} · {relation.supplierProductName}
+                            </p>
+                            <p className="text-xs text-gray-500">
+                              Código {relation.supplierProductCode} · Actualización {relation.supplierDate ?? '—'}
+                            </p>
+                          </div>
+                          <div className="text-sm text-gray-300">
+                            <p>Proveedor: {formatCurrency(relation.supplierPrice)}</p>
+                            <p>Gampack: {formatCurrency(relation.gampackPrice)}</p>
+                          </div>
                         </div>
+                        <p className={`mt-3 text-sm font-semibold ${differenceColor(relation.differencePct)}`}>
+                          {differenceLabel(relation.differencePct)}
+                        </p>
                       </li>
-                    );
-                  })}
-                </ul>
-              )}
-            </div>
+                    ))}
+                  </ul>
+                </article>
+              ))}
           </div>
-        </section>
-
-        <section className="flex-1">
-          <div className="flex h-full flex-col gap-4 rounded-2xl border border-gray-200 bg-white/90 p-4 shadow-sm dark:border-white/10 dark:bg-white/5">
-            <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-              <div className="flex flex-col gap-1">
-                <h3 className="text-base font-semibold text-gray-900 dark:text-white">
-                  Productos relacionados
-                </h3>
-                <p className="text-xs text-gray-500 dark:text-white/60">
-                  Visualizá los productos externos vinculados a los Gampack seleccionados.
-                </p>
-              </div>
-
-              <div className="flex flex-wrap items-center gap-2">
-                <div className="flex items-center gap-1 text-xs text-gray-500 dark:text-white/60">
-                  <Filter className="h-3.5 w-3.5" />
-                  {selectedProviders.length} / {providerOptions.length} proveedores
-                </div>
-                <button
-                  type="button"
-                  onClick={resetColumns}
-                  className="inline-flex items-center gap-1 rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition hover:border-blue-200 hover:text-blue-700 dark:border-white/10 dark:text-white/70 dark:hover:border-white/20 dark:hover:text-white"
-                >
-                  <ArrowUpDown className="h-3.5 w-3.5" /> Reset columnas
-                </button>
-              </div>
-            </header>
-
-            <div className="grid gap-3 lg:grid-cols-2">
-              <Input
-                value={relationSearch}
-                onChange={(event) => setRelationSearch(event.target.value)}
-                placeholder="Filtrar por proveedor, código o nombre"
-                className="dark:bg-white/10 dark:text-white dark:placeholder-white/60 dark:border-white/10 dark:focus:border-white/30 dark:focus:ring-white/20"
-              />
-
-              <div className="rounded-xl border border-gray-100 bg-white/70 p-3 text-xs shadow-sm dark:border-white/10 dark:bg-white/5">
-                <p className="mb-2 font-semibold text-gray-700 dark:text-white/80">Filtrar por proveedor</p>
-                {providerOptions.length === 0 ? (
-                  <p className="text-gray-500 dark:text-white/60">
-                    No hay proveedores para la selección actual.
-                  </p>
-                ) : (
-                  <div className="flex max-h-40 flex-col gap-1 overflow-y-auto pr-1">
-                    {providerOptions.map((provider) => {
-                      const checked = selectedProviders.includes(provider);
-                      return (
-                        <label
-                          key={provider}
-                          className="flex items-center justify-between gap-2 rounded-lg px-2 py-1 text-gray-600 transition hover:bg-blue-50/60 dark:text-white/70 dark:hover:bg-white/10"
-                        >
-                          <span className="flex-1 text-xs font-medium text-gray-700 dark:text-white">
-                            {provider}
-                          </span>
-                          <input
-                            type="checkbox"
-                            className="h-3.5 w-3.5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-white/20 dark:bg-transparent"
-                            checked={checked}
-                            onChange={(event) => toggleProvider(provider, event.target.checked)}
-                          />
-                        </label>
-                      );
-                    })}
-                  </div>
-                )}
-                {providerOptions.length > 0 && (
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    <button
-                      type="button"
-                      className="rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition hover:border-blue-200 hover:text-blue-700 dark:border-white/10 dark:text-white/70 dark:hover:border-white/20 dark:hover:text-white"
-                      onClick={() => setSelectedProviders(providerOptions)}
-                    >
-                      Todos
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 transition hover:border-blue-200 hover:text-blue-700 dark:border-white/10 dark:text-white/70 dark:hover:border-white/20 dark:hover:text-white"
-                      onClick={() => setSelectedProviders([])}
-                    >
-                      Ninguno
-                    </button>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            <div className="rounded-xl border border-gray-100 bg-white/70 p-3 shadow-sm dark:border-white/10 dark:bg-white/5">
-              <p className="mb-2 text-xs font-semibold text-gray-700 dark:text-white/80">
-                Ordenar columnas
-              </p>
-              <div className="flex flex-col gap-2">
-                {columnOrder.map((columnKey) => {
-                  const column = columnConfigMap[String(columnKey)];
-                  if (!column) return null;
-                  return (
-                    <div
-                      key={String(columnKey)}
-                      className="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs text-gray-600 shadow-sm transition hover:border-blue-200 hover:text-blue-700 dark:border-white/10 dark:bg-white/10 dark:text-white/70 dark:hover:border-white/20 dark:hover:text-white"
-                    >
-                      <span className="font-medium">{column.label}</span>
-                      <div className="flex items-center gap-2">
-                        <button
-                          type="button"
-                          onClick={() => moveColumn(columnKey, 'up')}
-                          className="rounded-full border border-gray-200 p-1 text-gray-500 transition hover:border-blue-200 hover:text-blue-600 dark:border-white/10 dark:text-white/60 dark:hover:border-white/20 dark:hover:text-white"
-                          aria-label={`Subir columna ${column.label}`}
-                        >
-                          <ChevronUp className="h-3.5 w-3.5" />
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => moveColumn(columnKey, 'down')}
-                          className="rounded-full border border-gray-200 p-1 text-gray-500 transition hover:border-blue-200 hover:text-blue-600 dark:border-white/10 dark:text-white/60 dark:hover:border-white/20 dark:hover:text-white"
-                          aria-label={`Bajar columna ${column.label}`}
-                        >
-                          <ChevronDown className="h-3.5 w-3.5" />
-                        </button>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-
-            <div className="flex-1">
-              {selectedGampacks.length === 0 ? (
-                <div className="flex h-full items-center justify-center rounded-2xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-white/20 dark:bg-white/5 dark:text-white/70">
-                  Seleccioná uno o más productos Gampack para ver sus relaciones.
-                </div>
-              ) : loadingRelations ? (
-                <div className="flex h-full items-center justify-center rounded-2xl border border-gray-200 bg-white/70 p-6 text-sm text-gray-500 shadow-inner dark:border-white/10 dark:bg-white/5 dark:text-white/70">
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Cargando relaciones...
-                </div>
-              ) : relations.length === 0 ? (
-                <div className="flex h-full items-center justify-center rounded-2xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-white/20 dark:bg-white/5 dark:text-white/70">
-                  No hay productos relacionados para la selección actual.
-                </div>
-              ) : (
-                <Table
-                  data={sortedRelations}
-                  columns={orderedColumns}
-                  onSort={handleSort}
-                  sortKey={sortKey || undefined}
-                  sortDirection={sortDirection}
-                  emptyMessage="No hay productos relacionados para la selección actual"
-                  className="h-full"
-                />
-              )}
-            </div>
-          </div>
-        </section>
-      </div>
+        )}
+      </section>
     </div>
   );
 };
 
-function buildRelationRows(rows: RawRelation[]): RelationRow[] {
-  const seen = new Map<string, RelationRow>();
-
-  rows.forEach((row) => {
-    const supplier = (row.proveedor ?? '').trim() || 'Sin proveedor';
-    const externalCode = row.cod_externo ?? '';
-    const externalName = row.nom_externo ?? '';
-    const gampackCode = row.cod_interno ?? '';
-    const gampackName = row.nom_interno ?? '';
-
-    const key = [supplier, row.id_lista_precios ?? '', externalCode, externalName]
-      .map((value) => String(value ?? '').toLowerCase().trim())
-      .join('|');
-
-    if (seen.has(key)) {
-      return;
-    }
-
-    seen.set(key, {
-      id: row.id,
-      supplier,
-      externalId: row.id_lista_precios,
-      externalCode: externalCode || '—',
-      externalName: externalName || 'Sin nombre',
-      externalPrice: row.precio_externo ?? null,
-      externalDate: row.fecha_externa ?? null,
-      gampackId: row.id_lista_interna ?? null,
-      gampackCode: gampackCode || '—',
-      gampackName: gampackName || 'Sin nombre',
-      gampackPrice: row.precio_interno ?? null,
-      gampackDate: row.fecha_interna ?? null,
-      relationCriteria: row.criterio_relacion ?? '',
-      relationCreatedAt: row.relation_created_at ?? null,
-    });
-  });
-
-  return Array.from(seen.values()).sort((a, b) =>
-    a.supplier.localeCompare(b.supplier, 'es')
-  );
-}
-
+export { SimplifiedComparisonView as GampackRelationsView };


### PR DESCRIPTION
## Summary
- replace the legacy Gampack relations alternate view with a new SimplifiedComparisonView built around a two-column layout
- fetch and group related supplier products for the current Gampack selection, highlighting price differences with intuitive color coding
- show clear selection feedback, loading states, and orphan relation handling while keeping the existing API interactions intact

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_690cfdbdf408832d89fa44ad61db2f24