### PR TITLE
Add safe numeric formatting to prevent toFixed crashes

### DIFF
--- a/project/server/index.js
+++ b/project/server/index.js
@@ -10,6 +10,38 @@ const { prepareSql } = require('./utils/sql');
 
 const app = express();
 
+const isFiniteNumber = (value) => typeof value === 'number' && Number.isFinite(value);
+
+const toFiniteNumber = (value) => {
+  if (isFiniteNumber(value)) {
+    return value;
+  }
+
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const safeToFixed = (value, decimals = 2, fallback = null) => {
+  const num = toFiniteNumber(value);
+  if (num == null) {
+    return fallback;
+  }
+  return num.toFixed(decimals);
+};
+
 // ===== Middlewares base =====
 const envOrigins = (process.env.ALLOWED_ORIGINS || '')
   .split(',')
@@ -2020,13 +2052,14 @@ app.get('/api/price-comparisons', async (req, res) => {
   try {
     const rows = await getDbRows(db, sql, params);
     const results = rows.map(row => {
-      const internal = row.internalfinalprice ?? row.internalfinalprice === 0 ? Number(row.internalfinalprice) : row.internalfinalprice;
-      const external = row.externalfinalprice ?? row.externalfinalprice === 0 ? Number(row.externalfinalprice) : row.externalfinalprice;
+      const internal = toFiniteNumber(row.internalfinalprice);
+      const external = toFiniteNumber(row.externalfinalprice);
 
-      const priceDifference =
-        external && external !== 0 && internal != null
-          ? parseFloat((((internal - external) / external) * 100).toFixed(2))
-          : null;
+      let priceDifference = null;
+      if (external != null && external !== 0 && internal != null) {
+        const diff = safeToFixed(((internal - external) / external) * 100, 2);
+        priceDifference = diff == null ? null : parseFloat(diff);
+      }
 
       return {
         internalProduct: row.internalproduct || null,
@@ -2070,16 +2103,25 @@ app.get('/api/gampack/:codigo/relacionados', async (req, res) => {
 
   try {
     const rows = await getDbRows(db, sql, [codInterno]);
-    const data = rows.map(row => ({
-      name: row.name,
-      price: row.price,
-      supplier: row.supplier,
-      externalDate: ensureYMD(row.externaldate),
-      priceDifference: (row.price ?? 0) - (row.internalprice ?? 0),
-      percentageDifference: row.internalprice
-        ? (((row.price ?? 0) - row.internalprice) / row.internalprice * 100).toFixed(2)
-        : '0.00'
-    }));
+    const data = rows.map(row => {
+      const price = toFiniteNumber(row.price);
+      const internalPrice = toFiniteNumber(row.internalprice);
+      const safePrice = price ?? 0;
+      const safeInternalPrice = internalPrice ?? 0;
+      const percentage =
+        internalPrice != null && internalPrice !== 0
+          ? safeToFixed(((safePrice - internalPrice) / internalPrice) * 100, 2, '0.00')
+          : '0.00';
+
+      return {
+        name: row.name,
+        price: row.price,
+        supplier: row.supplier,
+        externalDate: ensureYMD(row.externaldate),
+        priceDifference: safePrice - safeInternalPrice,
+        percentageDifference: percentage,
+      };
+    });
     res.json(data);
   } catch (err) {
     console.error('Error al obtener productos relacionados:', err);

--- a/project/src/components/GampackRelationsView.tsx
+++ b/project/src/components/GampackRelationsView.tsx
@@ -3,6 +3,7 @@ import { Loader2, CheckCircle2 } from 'lucide-react';
 
 import { apiFetch } from '../lib/api';
 import { Input } from './Input';
+import { isFiniteNumber, safeToFixed } from '../utils/number';
 
 type GampackProduct = {
   id_interno: number;
@@ -72,8 +73,8 @@ const parseIdsFromQuery = (raw: unknown): number[] => {
 };
 
 const formatCurrency = (value: number | null): string => {
-  if (value == null || Number.isNaN(value)) return '—';
-  return `$${value.toFixed(2)}`;
+  const formatted = safeToFixed(value, 2);
+  return formatted === '—' ? '—' : `$${formatted}`;
 };
 
 const buildSimplifiedRelations = (rows: RawRelation[]): SimplifiedRelation[] => {
@@ -121,15 +122,15 @@ const buildSimplifiedRelations = (rows: RawRelation[]): SimplifiedRelation[] => 
 };
 
 const differenceColor = (difference: number | null): string => {
-  if (difference == null) return 'text-gray-400';
+  if (!isFiniteNumber(difference)) return 'text-gray-400';
   if (difference < 0) return 'text-green-400';
   if (difference > 0) return 'text-red-400';
   return 'text-gray-400';
 };
 
 const differenceLabel = (difference: number | null): string => {
-  if (difference == null) return 'Diferencia: sin datos ⚪';
-  const formatted = `${difference > 0 ? '+' : ''}${difference.toFixed(1)}%`;
+  if (!isFiniteNumber(difference)) return 'Diferencia: sin datos ⚪';
+  const formatted = `${difference > 0 ? '+' : ''}${safeToFixed(difference, 1)}%`;
   if (difference < 0) {
     return `Diferencia: ${formatted} 🟢`;
   }

--- a/project/src/screens/venta/CompareScreen.tsx
+++ b/project/src/screens/venta/CompareScreen.tsx
@@ -7,6 +7,7 @@ import { Search, List, LayoutGrid, CalendarDays, XCircle, Loader2 } from 'lucide
 import { Screen } from '../../types';
 import { apiFetch } from '../../lib/api';
 import { GampackRelationsView } from '../../components/GampackRelationsView';
+import { isFiniteNumber, safeToFixed, toFiniteNumber } from '../../utils/number';
 
 interface CompareScreenProps {
   onNavigate: (screen: Screen) => void;
@@ -255,46 +256,58 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
 
   // Helpers diferencia
   const getDifferencePct = (internal?: number | null, external?: number | null) => {
-    if (external == null || external === 0 || internal == null) return null;
-    const diff = ((internal - external) / external) * 100;
-    return parseFloat(diff.toFixed(2));
+    const internalValue = toFiniteNumber(internal);
+    const externalValue = toFiniteNumber(external);
+    if (externalValue == null || externalValue === 0 || internalValue == null) return null;
+    const diff = ((internalValue - externalValue) / externalValue) * 100;
+    const formatted = safeToFixed(diff, 2);
+    return formatted === '—' ? null : Number.parseFloat(formatted);
   };
   const getDifferenceAmt = (internal?: number | null, external?: number | null) => {
-    if (internal == null || external == null) return null;
-    const amt = internal - external;
-    return parseFloat(amt.toFixed(2));
+    const internalValue = toFiniteNumber(internal);
+    const externalValue = toFiniteNumber(external);
+    if (internalValue == null || externalValue == null) return null;
+    const amt = internalValue - externalValue;
+    const formatted = safeToFixed(amt, 2);
+    return formatted === '—' ? null : Number.parseFloat(formatted);
   };
   const formatSignedMoney = (n: number) => {
+    if (!isFiniteNumber(n)) {
+      return '—';
+    }
     const sign = n > 0 ? '+' : n < 0 ? '−' : '';
-    const abs = Math.abs(n).toFixed(2);
-    return `${sign}$${abs}`;
+    const abs = safeToFixed(Math.abs(n), 2);
+    return abs === '—' ? '—' : `${sign}$${abs}`;
   };
 
   // Veredicto textual
   function getVerdict(internal?: number | null, external?: number | null) {
-    if (internal == null || external == null) {
+    const internalValue = toFiniteNumber(internal);
+    const externalValue = toFiniteNumber(external);
+
+    if (internalValue == null || externalValue == null) {
       return {
         tone: 'na' as const,
         text: 'Sin suficientes datos para comparar.',
         classes: 'text-gray-600 dark:text-white/70'
       };
     }
-    if (internal < external) {
-      const ahorro = external - internal;
-      const pct = (ahorro / external) * 100;
+    if (internalValue < externalValue) {
+      const ahorro = externalValue - internalValue;
+      const pct = (ahorro / externalValue) * 100;
       return {
         tone: 'cheaper' as const,
-        text: `Gampack es más barato: ahorrás $${ahorro.toFixed(2)} (${pct.toFixed(2)}%) frente al proveedor.`,
+        text: `Gampack es más barato: ahorrás $${safeToFixed(ahorro, 2)} (${safeToFixed(pct, 2)}%) frente al proveedor.`,
         classes:
           'bg-green-50 text-green-800 border-green-300/40 dark:bg-green-500/10 dark:text-green-200 dark:border-green-500/20'
       };
     }
-    if (internal > external) {
-      const extra = internal - external;
-      const pct = (extra / external) * 100;
+    if (internalValue > externalValue) {
+      const extra = internalValue - externalValue;
+      const pct = (extra / externalValue) * 100;
       return {
         tone: 'expensive' as const,
-        text: `Gampack es más caro: +$${extra.toFixed(2)} (+${pct.toFixed(2)}%) vs el proveedor.`,
+        text: `Gampack es más caro: +$${safeToFixed(extra, 2)} (+${safeToFixed(pct, 2)}%) vs el proveedor.`,
         classes:
           'bg-red-50 text-red-800 border-red-300/40 dark:bg-red-500/10 dark:text-red-200 dark:border-red-500/20'
       };
@@ -531,8 +544,8 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
               columns={[
                 { key: 'internalProduct', label: 'Producto Interno', sortable: true, render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
                 { key: 'externalProduct', label: 'Producto Proveedor', sortable: true, render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
-                { key: 'internalFinalPrice', label: 'Final Interno', sortable: true, render: (v: any) => <span className="dark:text-white">{typeof v === 'number' ? `$${v.toFixed(2)}` : '—'}</span> },
-                { key: 'externalFinalPrice', label: 'Final Proveedor', sortable: true, render: (v: any) => <span className="dark:text-white">{typeof v === 'number' ? `$${v.toFixed(2)}` : '—'}</span> },
+                { key: 'internalFinalPrice', label: 'Final Interno', sortable: true, render: (v: any) => <span className="dark:text-white">{isFiniteNumber(v) ? `$${safeToFixed(v, 2)}` : '—'}</span> },
+                { key: 'externalFinalPrice', label: 'Final Proveedor', sortable: true, render: (v: any) => <span className="dark:text-white">{isFiniteNumber(v) ? `$${safeToFixed(v, 2)}` : '—'}</span> },
                 { key: 'internalDate', label: 'Fecha Interna', render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
                 { key: 'externalDate', label: 'Fecha Proveedor', render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
                 { key: 'supplier', label: 'Proveedor', render: (v: any) => <span className="dark:text-white">{v ?? '—'}</span> },
@@ -555,8 +568,8 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
                   key: 'conclusion',
                   label: 'Conclusión',
                   render: (_v: any, row: any) => {
-                    const internal = typeof row.internalFinalPrice === 'number' ? row.internalFinalPrice : null;
-                    const external = typeof row.externalFinalPrice === 'number' ? row.externalFinalPrice : null;
+                    const internal = isFiniteNumber(row.internalFinalPrice) ? row.internalFinalPrice : null;
+                    const external = isFiniteNumber(row.externalFinalPrice) ? row.externalFinalPrice : null;
                     const verdict = getVerdict(internal, external);
                     return (
                       <span
@@ -577,8 +590,8 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
             <div className="grid grid-cols-1 gap-4">
               {loading && <div className="text-sm text-gray-600 dark:text-white/70">Cargando...</div>}
               {!loading && comparisons.map((item, i) => {
-                const internal = typeof item.internalFinalPrice === 'number' ? item.internalFinalPrice : null;
-                const external = typeof item.externalFinalPrice === 'number' ? item.externalFinalPrice : null;
+                const internal = isFiniteNumber(item.internalFinalPrice) ? item.internalFinalPrice : null;
+                const external = isFiniteNumber(item.externalFinalPrice) ? item.externalFinalPrice : null;
                 const pct = getDifferencePct(internal, external);
                 const amt = getDifferenceAmt(internal, external);
                 const verdict = getVerdict(internal, external);
@@ -604,7 +617,7 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
                         <p className="text-xs text-gray-500 dark:text-white/60">Producto Gampack</p>
                         <p className="text-base font-semibold text-gray-900 dark:text-white">{item.internalProduct ?? '—'}</p>
                         <p className="text-xs text-gray-500 dark:text-white/60 mt-1">Precio Interno</p>
-                        <p className="text-lg font-bold text-green-600">{internal != null ? `$${internal.toFixed(2)}` : '—'}</p>
+                        <p className="text-lg font-bold text-green-600">{internal != null ? `$${safeToFixed(internal, 2)}` : '—'}</p>
                       </div>
                       <div className="text-center">
                         <p className="text-xs text-gray-500 dark:text-white/60">Diferencia</p>
@@ -621,7 +634,7 @@ export const CompareScreen: React.FC<CompareScreenProps> = ({ onNavigate }) => {
                         <p className="text-xs text-gray-500 dark:text-white/60">Producto Proveedor</p>
                         <p className="text-base font-semibold text-gray-900 dark:text-white">{item.externalProduct ?? '—'}</p>
                         <p className="text-xs text-gray-500 dark:text-white/60 mt-1">Precio Externo</p>
-                        <p className="text-lg font-bold text-blue-600">{external != null ? `$${external.toFixed(2)}` : '—'}</p>
+                        <p className="text-lg font-bold text-blue-600">{external != null ? `$${safeToFixed(external, 2)}` : '—'}</p>
                       </div>
                     </div>
 

--- a/project/src/screens/venta/UnmatchedEquivalencesScreen.tsx
+++ b/project/src/screens/venta/UnmatchedEquivalencesScreen.tsx
@@ -5,6 +5,7 @@ import { Screen } from '../../types';
 import { apiFetch } from '../../lib/api';
 import { Trash2 } from 'lucide-react';
 import { formatYMD, compareYMD, formatYearMonth, compareYearMonth } from '../../utils/date';
+import { isFiniteNumber, safeToFixed } from '../../utils/number';
 
 
 /* ---------- Similaridad mejorada: trigramas + Levenshtein + fonética ---------- */
@@ -219,6 +220,7 @@ export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen
 
   // umbral similitud
   const [threshold, setThreshold] = useState<number>(DEFAULT_SIMILARITY_THRESHOLD);
+  const thresholdLabel = safeToFixed(threshold, 2);
 
   // Top button
   const [showTop, setShowTop] = useState(false);
@@ -328,23 +330,30 @@ const generateAutoMatches = useCallback(async () => {
         const id = `${i.id_interno}|${e.id_externo}`;
         if (ignoredPairs.has(id) || seen.has(id)) continue;
 
-        const score = cosineByTri(
+        const rawScore = cosineByTri(
           iTri,
           eIdx.tri,
           iSan,
           sanitizeText(eName)
         );
 
+        if (!isFiniteNumber(rawScore)) {
+          continue;
+        }
+
+        const score = rawScore;
+
         // 🔍 Muestra los puntajes en consola
+        const scoreForLog = safeToFixed(score, 3);
         console.log(
-          `Comparando "${iName}" ↔ "${eName}" → score: ${score.toFixed(3)}`
+          `Comparando "${iName}" ↔ "${eName}" → score: ${scoreForLog}`
         );
 
         if (score >= threshold) {
           acc.push({
             internal: i,
             external: e,
-            reason: `Nombre similar (${score.toFixed(2)})`,
+            reason: `Nombre similar (${safeToFixed(score, 2)})`,
             score,
             id,
           });
@@ -580,7 +589,7 @@ const generateAutoMatches = useCallback(async () => {
               </div>
 
               <div className="flex-shrink-0 flex flex-col items-end gap-2">
-                <div className="text-xs text-gray-600 dark:text-gray-300">Umbral: <b>{threshold.toFixed(2)}</b></div>
+                <div className="text-xs text-gray-600 dark:text-gray-300">Umbral: <b>{thresholdLabel}</b></div>
                 <input type="range" min={0.3} max={0.9} step={0.01} value={threshold} onChange={e => setThreshold(parseFloat(e.target.value))} className="w-40 accent-blue-600" />
                 <Button onClick={generateAutoMatches} disabled={loadingAuto}>{loadingAuto ? 'Buscando coincidencias…' : 'Relacionar automáticamente'}</Button>
               </div>
@@ -607,11 +616,13 @@ const generateAutoMatches = useCallback(async () => {
                 </div>
                 {loadingAuto && <div className="mt-3 h-1 w-full bg-blue-200/50 dark:bg-blue-950/50 rounded"><div className="h-1 w-1/3 animate-pulse bg-blue-600 rounded" /></div>}
                 <div className="mt-3 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 max-h-[420px] overflow-auto pr-1">
-                  {suggestions.length === 0 && !loadingAuto && <div className="col-span-full text-sm text-blue-900/80 dark:text-blue-100/80">No hay coincidencias por encima del umbral ({threshold.toFixed(2)}).</div>}
-                  {suggestions.map((s) => (
-                    <div key={s.id} className="rounded-xl bg-white dark:bg-[#0e1526] border border-blue-200/50 dark:border-white/10 p-4 shadow">
+                  {suggestions.length === 0 && !loadingAuto && <div className="col-span-full text-sm text-blue-900/80 dark:text-blue-100/80">No hay coincidencias por encima del umbral ({thresholdLabel}).</div>}
+                  {suggestions.map((s) => {
+                    const scoreBadge = safeToFixed(s.score * 100, 0);
+                    return (
+                      <div key={s.id} className="rounded-xl bg-white dark:bg-[#0e1526] border border-blue-200/50 dark:border-white/10 p-4 shadow">
                       <div className="text-xs uppercase tracking-wide text-blue-700 dark:text-blue-300 mb-2 flex items-center justify-between">
-                        <span>{s.reason}</span><span className="px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-[10px] font-semibold">{(s.score*100).toFixed(0)}%</span>
+                        <span>{s.reason}</span><span className="px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-[10px] font-semibold">{scoreBadge === '—' ? '—' : `${scoreBadge}%`}</span>
                       </div>
                       <div className="space-y-2">
                         <div className="text-sm">
@@ -628,8 +639,9 @@ const generateAutoMatches = useCallback(async () => {
                         <Button onClick={() => acceptSuggestion(s)}>Aceptar</Button>
                         <Button onClick={() => rejectSuggestion(s)} variant="secondary">Descartar</Button>
                       </div>
-                    </div>
-                  ))}
+                      </div>
+                    );
+                  })}
                 </div>
               </div>
             </div>

--- a/project/src/utils/number.ts
+++ b/project/src/utils/number.ts
@@ -1,0 +1,33 @@
+export const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+export const toFiniteNumber = (value: unknown): number | null => {
+  if (isFiniteNumber(value)) {
+    return value;
+  }
+
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+export const safeToFixed = (
+  value: unknown,
+  decimals = 2,
+  fallback = '—'
+): string => {
+  const num = toFiniteNumber(value);
+  return num == null ? fallback : num.toFixed(decimals);
+};


### PR DESCRIPTION
## Summary
- add reusable numeric helpers and apply them across price comparison views to guard `toFixed` usage
- normalise server-side numeric values before formatting percentage differences
- show an em dash fallback whenever comparison values are missing or invalid instead of throwing

## Testing
- npm run build *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_b_690d063bfe10832dacda6be1aa0fcdc0