### PR TITLE
Improve product search ranking

### DIFF
--- a/project/src/components/GampackRelationsView.tsx
+++ b/project/src/components/GampackRelationsView.tsx
@@ -14,6 +14,7 @@ import { apiFetch } from '../lib/api';
 import { Input } from './Input';
 import { isFiniteNumber, safeToFixed } from '../utils/number';
 import { useTheme } from '../context/theme';
+import { getBestSearchRank, normalizeSearchTerm } from '../utils/search';
 
 type GampackProduct = {
   id_interno: number;
@@ -426,14 +427,22 @@ export const SimplifiedComparisonView: React.FC<SimplifiedComparisonViewProps> =
   );
 
   const filteredGampackItems = useMemo(() => {
-    if (!gampackSearch.trim()) return gampackItemsWithRelations;
-    const search = gampackSearch.trim().toLowerCase();
-    return gampackItemsWithRelations.filter((item) => {
-      const haystack = [item.nom_interno, item.cod_interno]
-        .map((value) => value?.toString().toLowerCase() ?? '')
-        .join(' ');
-      return haystack.includes(search);
-    });
+    const normalizedQuery = normalizeSearchTerm(gampackSearch);
+    if (!normalizedQuery) return gampackItemsWithRelations;
+
+    return gampackItemsWithRelations
+      .map((item) => ({
+        item,
+        rank: getBestSearchRank([item.nom_interno, item.cod_interno], normalizedQuery),
+      }))
+      .filter((entry) => entry.rank != null)
+      .sort((a, b) => {
+        if (a.rank !== b.rank) {
+          return (a.rank ?? 0) - (b.rank ?? 0);
+        }
+        return (a.item.nom_interno ?? '').localeCompare(b.item.nom_interno ?? '', 'es');
+      })
+      .map((entry) => entry.item);
   }, [gampackItemsWithRelations, gampackSearch]);
 
   const selectedDetails = useMemo<SelectedSummary[]>(() => {

--- a/project/src/screens/venta/UnmatchedEquivalencesScreen.tsx
+++ b/project/src/screens/venta/UnmatchedEquivalencesScreen.tsx
@@ -6,6 +6,7 @@ import { apiFetch } from '../../lib/api';
 import { Trash2 } from 'lucide-react';
 import { formatYMD, compareYMD, formatYearMonth, compareYearMonth } from '../../utils/date';
 import { isFiniteNumber, safeToFixed } from '../../utils/number';
+import { getBestSearchRank, normalizeSearchTerm } from '../../utils/search';
 
 
 /* ---------- Similaridad mejorada: trigramas + Levenshtein + fonética ---------- */
@@ -487,33 +488,57 @@ const generateAutoMatches = useCallback(async () => {
 
   /* ---------- Filtrado/sort ---------- */
   const filteredSortedExternals = useMemo(() => {
-    const q = normalizeStr(dSearchExt);
-    const filtered = externals.filter(r => !q || normalizeStr(r.cod_externo).includes(q) || normalizeStr(r.nom_externo).includes(q) || normalizeStr(r.proveedor).includes(q));
-    const sorted = [...filtered].sort((a, b) => {
-      const av: any = a[sortExtKey];
-      const bv: any = b[sortExtKey];
+    const normalizedQuery = normalizeSearchTerm(dSearchExt);
+    const ranked = externals
+      .map((item) => ({
+        item,
+        rank: normalizedQuery
+          ? getBestSearchRank([item.cod_externo, item.nom_externo, item.proveedor], normalizedQuery)
+          : null,
+      }))
+      .filter((entry) => (normalizedQuery ? entry.rank != null : true));
+
+    const sorted = [...ranked].sort((a, b) => {
+      if (normalizedQuery && a.rank !== b.rank) {
+        return (a.rank ?? 0) - (b.rank ?? 0);
+      }
+      const av: any = a.item[sortExtKey];
+      const bv: any = b.item[sortExtKey];
       let r: number;
       if (sortExtKey === 'fecha') r = compareYMD(av, bv);
       else if (sortExtKey === 'mes_actualizacion') r = compareYearMonth(av, bv);
       else r = cmp(normalizeStr(av), normalizeStr(bv));
       return sortExtDir === 'asc' ? r : -r;
     });
-    return sorted;
+
+    return sorted.map((entry) => entry.item);
   }, [externals, dSearchExt, sortExtKey, sortExtDir]);
 
   const filteredSortedInternals = useMemo(() => {
-    const q = normalizeStr(dSearchInt);
-    const filtered = internals.filter(r => !q || normalizeStr(r.cod_interno).includes(q) || normalizeStr(r.nom_interno).includes(q));
-    const sorted = [...filtered].sort((a, b) => {
-      const av: any = a[sortIntKey];
-      const bv: any = b[sortIntKey];
+    const normalizedQuery = normalizeSearchTerm(dSearchInt);
+    const ranked = internals
+      .map((item) => ({
+        item,
+        rank: normalizedQuery
+          ? getBestSearchRank([item.cod_interno, item.nom_interno], normalizedQuery)
+          : null,
+      }))
+      .filter((entry) => (normalizedQuery ? entry.rank != null : true));
+
+    const sorted = [...ranked].sort((a, b) => {
+      if (normalizedQuery && a.rank !== b.rank) {
+        return (a.rank ?? 0) - (b.rank ?? 0);
+      }
+      const av: any = a.item[sortIntKey];
+      const bv: any = b.item[sortIntKey];
       let r: number;
       if (sortIntKey === 'fecha') r = compareYMD(av, bv);
       else if (sortIntKey === 'mes_actualizacion') r = compareYearMonth(av, bv);
       else r = cmp(normalizeStr(av), normalizeStr(bv));
       return sortIntDir === 'asc' ? r : -r;
     });
-    return sorted;
+
+    return sorted.map((entry) => entry.item);
   }, [internals, dSearchInt, sortIntKey, sortIntDir]);
 
   const toggleSortExternal = (key: SortKeyExternal) => {

--- a/project/src/utils/search.ts
+++ b/project/src/utils/search.ts
@@ -1,0 +1,62 @@
+export type SearchRank = 1 | 2 | 3;
+
+const WORD_SEPARATOR = /[\s,.;:/\\-]+/;
+
+const removeDiacritics = (value: string) =>
+  value.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+
+export const normalizeSearchTerm = (value: string) =>
+  removeDiacritics(String(value ?? ''))
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const getRankFromNormalized = (
+  normalizedHaystack: string,
+  normalizedQuery: string
+): SearchRank | null => {
+  if (!normalizedHaystack || !normalizedQuery) {
+    return null;
+  }
+
+  if (normalizedHaystack.startsWith(normalizedQuery)) {
+    return 1;
+  }
+
+  const words = normalizedHaystack.split(WORD_SEPARATOR).filter(Boolean);
+  if (words.some((word) => word === normalizedQuery)) {
+    return 2;
+  }
+
+  if (normalizedHaystack.includes(normalizedQuery)) {
+    return 3;
+  }
+
+  return null;
+};
+
+export const getBestSearchRank = (
+  values: Array<string | number | null | undefined>,
+  normalizedQuery: string
+): SearchRank | null => {
+  if (!normalizedQuery) {
+    return null;
+  }
+
+  let best: SearchRank | null = null;
+  for (const value of values) {
+    if (value == null) continue;
+    const normalizedValue = normalizeSearchTerm(String(value));
+    if (!normalizedValue) continue;
+    const rank = getRankFromNormalized(normalizedValue, normalizedQuery);
+    if (rank == null) continue;
+    if (best == null || rank < best) {
+      best = rank;
+      if (rank === 1) {
+        break;
+      }
+    }
+  }
+
+  return best;
+};


### PR DESCRIPTION
## Summary
- add reusable helpers to normalize queries and assign literal search ranks
- update the Gampack picker to prioritize prefix/whole-word matches before partial hits
- apply the same ranked filtering to the external/internal tables on the relaciones pendientes screen

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69174518dc20832d94614f829f787ef7)