### PR TITLE
Implement progressive loading for supplier data

### DIFF
--- a/project/server/index.js
+++ b/project/server/index.js
@@ -175,14 +175,10 @@ async function getDbRows(db, sql, params = []) {
 }
 
 function parseLimitParam(raw) {
-  const DEFAULT_LIMIT = 500;
-  const MIN_LIMIT = 50;
-  const MAX_LIMIT = 2000;
+  const DEFAULT_LIMIT = 1000;
   if (raw == null) return DEFAULT_LIMIT;
   const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed)) return DEFAULT_LIMIT;
-  if (parsed < MIN_LIMIT) return MIN_LIMIT;
-  if (parsed > MAX_LIMIT) return MAX_LIMIT;
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIMIT;
   return parsed;
 }
 
@@ -843,8 +839,7 @@ app.get('/api/providers/products', async (req, res) => {
     }
     const isGampack = normalizedName === 'gampack';
 
-    const rawLimit = Number.parseInt(req.query.limit, 10);
-    const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(rawLimit, 500) : 100;
+    const limit = parseLimitParam(req.query.limit);
     const rawOffset = Number.parseInt(req.query.offset, 10);
     const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
 
@@ -928,6 +923,7 @@ app.get('/api/providers/products', async (req, res) => {
       total,
       limit,
       offset,
+      hasMore: offset + normalized.length < total,
     });
   } catch (err) {
     console.error('Error /api/providers/products:', err);

--- a/project/src/hooks/useProgressiveBatchLoader.ts
+++ b/project/src/hooks/useProgressiveBatchLoader.ts
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { DependencyList, Dispatch, SetStateAction } from 'react';
+
+export type ProgressiveBatchPage<T> = {
+  items: T[];
+  total?: number | null;
+  hasMore?: boolean;
+};
+
+export type ProgressiveBatchResult<T> = {
+  items: T[];
+  setItems: Dispatch<SetStateAction<T[]>>;
+  total: number | null;
+  setTotal: Dispatch<SetStateAction<number | null>>;
+  loadedCount: number;
+  isLoadingInitial: boolean;
+  isLoadingMore: boolean;
+  error: string | null;
+  reload: () => void;
+};
+
+type LoaderOptions<T> = {
+  fetchPage: (offset: number, limit: number, signal: AbortSignal) => Promise<ProgressiveBatchPage<T>>;
+  limit?: number;
+  enabled: boolean;
+  deps?: DependencyList;
+};
+
+export function useProgressiveBatchLoader<T>({
+  fetchPage,
+  limit = 1000,
+  enabled,
+  deps = [],
+}: LoaderOptions<T>): ProgressiveBatchResult<T> {
+  const [items, setItems] = useState<T[]>([]);
+  const [total, setTotal] = useState<number | null>(null);
+  const [loadedCount, setLoadedCount] = useState(0);
+  const [isLoadingInitial, setIsLoadingInitial] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    if (!enabled) {
+      setItems([]);
+      setTotal(null);
+      setLoadedCount(0);
+      setIsLoadingInitial(false);
+      setIsLoadingMore(false);
+      setError(null);
+      return;
+    }
+
+    let isMounted = true;
+    const controller = new AbortController();
+    setIsLoadingInitial(true);
+    setIsLoadingMore(false);
+    setError(null);
+    setItems([]);
+    setTotal(null);
+    setLoadedCount(0);
+
+    const load = async () => {
+      let offsetValue = 0;
+      let isFirstBatch = true;
+
+      while (isMounted && !controller.signal.aborted) {
+        setIsLoadingMore(!isFirstBatch);
+        try {
+          const page = await fetchPage(offsetValue, limit, controller.signal);
+          if (!isMounted || controller.signal.aborted) {
+            return;
+          }
+          const chunk = Array.isArray(page?.items) ? page.items : [];
+          setItems((prev) => (isFirstBatch ? chunk : [...prev, ...chunk]));
+          if (typeof page?.total === 'number') {
+            setTotal(page.total);
+          }
+          setIsLoadingInitial(false);
+
+          const hasMore =
+            typeof page?.hasMore === 'boolean'
+              ? page.hasMore
+              : typeof page?.total === 'number'
+              ? offsetValue + chunk.length < page.total
+              : chunk.length === limit;
+
+          if (!hasMore || chunk.length === 0) {
+            break;
+          }
+
+          offsetValue += limit;
+          isFirstBatch = false;
+        } catch (err) {
+          if (!isMounted || controller.signal.aborted) {
+            return;
+          }
+          console.error('Progressive batch loader error:', err);
+          setError(err instanceof Error ? err.message : 'No se pudieron cargar los datos.');
+          break;
+        }
+      }
+
+      if (isMounted && !controller.signal.aborted) {
+        setIsLoadingInitial(false);
+        setIsLoadingMore(false);
+      }
+    };
+
+    load();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [enabled, fetchPage, limit, reloadToken, ...deps]);
+
+  useEffect(() => {
+    setLoadedCount(items.length);
+  }, [items]);
+
+  const reload = useCallback(() => {
+    setReloadToken((token) => token + 1);
+  }, []);
+
+  return {
+    items,
+    setItems,
+    total,
+    setTotal,
+    loadedCount,
+    isLoadingInitial,
+    isLoadingMore,
+    error,
+    reload,
+  };
+}

--- a/project/src/screens/venta/ActiveSuppliersScreen.tsx
+++ b/project/src/screens/venta/ActiveSuppliersScreen.tsx
@@ -1,7 +1,8 @@
-import React, { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { Navigation } from '../../components/Navigation';
 import { Screen } from '../../types';
 import { apiFetch } from '../../lib/api';
+import { useProgressiveBatchLoader } from '../../hooks/useProgressiveBatchLoader';
 import {
   AlertCircle,
   AlertTriangle,
@@ -105,6 +106,7 @@ const statusBadgeClass = (isActive: boolean) =>
   ].join(' ');
 
 const DATABASE_RESET_PHRASE = 'Quiero borrar la base de datos';
+const PROVIDER_PRODUCTS_PAGE_SIZE = 1000;
 
 const ActiveSuppliersScreen: React.FC<ActiveSuppliersScreenProps> = ({ onNavigate }) => {
   const [providers, setProviders] = useState<ProviderSummary[]>([]);
@@ -112,17 +114,10 @@ const ActiveSuppliersScreen: React.FC<ActiveSuppliersScreenProps> = ({ onNavigat
   const [search, setSearch] = useState('');
 
   const [selectedProvider, setSelectedProvider] = useState<ProviderSummary | null>(null);
-  const [products, setProducts] = useState<ProviderProduct[]>([]);
-  const [loadingProducts, setLoadingProducts] = useState(false);
-  const [productsError, setProductsError] = useState<string | null>(null);
-  const [productSearch, setProductSearch] = useState('');
   const [productDrafts, setProductDrafts] = useState<Record<string, ProductDraft>>({});
   const [savingProducts, setSavingProducts] = useState<Record<string, boolean>>({});
   const [productErrors, setProductErrors] = useState<Record<string, string | null>>({});
-  const [offset, setOffset] = useState(0);
-  const [limit] = useState(100);
-  const [total, setTotal] = useState<number | null>(null);
-  const [loadingMore, setLoadingMore] = useState(false);
+  const [productSearch, setProductSearch] = useState('');
   const [deletingProvider, setDeletingProvider] = useState<string | null>(null);
   const [actionFeedback, setActionFeedback] = useState<ActionFeedback | null>(null);
   const [bulkDialogOpen, setBulkDialogOpen] = useState(false);
@@ -134,8 +129,7 @@ const ActiveSuppliersScreen: React.FC<ActiveSuppliersScreenProps> = ({ onNavigat
   const [resetPhrase, setResetPhrase] = useState('');
   const [resetError, setResetError] = useState<string | null>(null);
   const [resetLoading, setResetLoading] = useState(false);
-  const loadingMoreRef = useRef(false);
-  const skipNextFetchRef = useRef(false);
+  const deferredProductSearch = useDeferredValue(productSearch);
 
   useEffect(() => {
     const fetchProviders = async () => {
@@ -202,37 +196,88 @@ const ActiveSuppliersScreen: React.FC<ActiveSuppliersScreenProps> = ({ onNavigat
 
   const handleOpenProvider = (provider: ProviderSummary) => {
     setSelectedProvider(provider);
-    setLoadingProducts(true);
-    setProductsError(null);
-    setProducts([]);
     setProductSearch('');
     setProductDrafts({});
     setSavingProducts({});
     setProductErrors({});
-    setOffset(0);
     setTotal(null);
-    setLoadingMore(false);
-    loadingMoreRef.current = false;
-    skipNextFetchRef.current = false;
   };
 
   const handleCloseModal = () => {
     setSelectedProvider(null);
-    setProducts([]);
-    setProductsError(null);
     setProductDrafts({});
     setSavingProducts({});
     setProductErrors({});
-    setLoadingProducts(false);
-    setOffset(0);
     setTotal(null);
-    setLoadingMore(false);
-    loadingMoreRef.current = false;
-    skipNextFetchRef.current = false;
     setProductSearch('');
   };
 
-  const deferredProductSearch = useDeferredValue(productSearch);
+  const providerName = selectedProvider?.name?.trim() || null;
+
+  const fetchProviderProductsPage = useCallback(
+    async (offset: number, limit: number, signal: AbortSignal) => {
+      if (!providerName) {
+        return { items: [], total: 0, hasMore: false };
+      }
+
+      const response = await apiFetch(
+        `/api/providers/products?name=${encodeURIComponent(providerName)}&limit=${limit}&offset=${offset}`,
+        { signal }
+      );
+      if (!response.ok) {
+        throw new Error(await parseErrorResponse(response));
+      }
+      const data = await response.json();
+      const normalizedProducts: ProviderProduct[] = Array.isArray(data?.products)
+        ? data.products.map((product: any, index: number) => ({
+            id:
+              product?.id ??
+              product?.id_externo ??
+              product?.id_interno ??
+              `${product?.code ?? product?.cod_externo ?? 'producto'}-${offset + index}`,
+            name: String(product?.name ?? product?.nom_externo ?? 'Producto sin nombre'),
+            code: product?.code ?? product?.cod_externo ?? null,
+            price: Number(product?.price ?? product?.precio_final ?? 0),
+            date: product?.date ?? product?.fecha ?? null,
+            companyType: product?.companyType ?? product?.tipo_empresa ?? null,
+            family: product?.family ?? product?.familia ?? null,
+            isActive: Boolean(product?.isActive ?? product?.is_active ?? false),
+          }))
+        : [];
+
+      const parsedTotal = Number(data?.total);
+      const hasMore =
+        typeof data?.hasMore === 'boolean'
+          ? Boolean(data.hasMore)
+          : Number.isFinite(parsedTotal)
+          ? offset + normalizedProducts.length < parsedTotal
+          : normalizedProducts.length === limit;
+
+      return {
+        items: normalizedProducts,
+        total: Number.isFinite(parsedTotal) ? parsedTotal : null,
+        hasMore,
+      };
+    },
+    [providerName]
+  );
+
+  const {
+    items: products,
+    setItems: setProducts,
+    total,
+    setTotal,
+    loadedCount,
+    isLoadingInitial,
+    isLoadingMore,
+    error: productsError,
+    reload: reloadProducts,
+  } = useProgressiveBatchLoader<ProviderProduct>({
+    enabled: Boolean(providerName),
+    limit: PROVIDER_PRODUCTS_PAGE_SIZE,
+    deps: [providerName],
+    fetchPage: fetchProviderProductsPage,
+  });
 
   const displayedProducts = useMemo(() => {
     const query = deferredProductSearch.trim().toLowerCase();
@@ -254,105 +299,7 @@ const ActiveSuppliersScreen: React.FC<ActiveSuppliersScreenProps> = ({ onNavigat
   const totalProductsCount =
     typeof total === 'number'
       ? total
-      : selectedProvider?.products ?? displayedProducts.length;
-
-  const providerName = selectedProvider?.name ?? null;
-
-  useEffect(() => {
-    if (!providerName) return;
-    if (skipNextFetchRef.current) {
-      skipNextFetchRef.current = false;
-      return;
-    }
-
-    let isActive = true;
-    const fetchProducts = async () => {
-      const isInitialLoad = offset === 0;
-      if (isInitialLoad) {
-        setProductsError(null);
-        setLoadingProducts(true);
-      }
-
-      try {
-        const response = await apiFetch(
-          `/api/providers/products?name=${encodeURIComponent(
-            providerName
-          )}&limit=${limit}&offset=${offset}`
-        );
-        if (!response.ok) {
-          throw new Error(await parseErrorResponse(response));
-        }
-        const data = await response.json();
-        if (!isActive) return;
-
-        const normalizedProducts: ProviderProduct[] = Array.isArray(data?.products)
-          ? data.products.map((product: any, index: number) => ({
-              id:
-                product?.id ??
-                product?.id_externo ??
-                `${product?.code ?? product?.cod_externo ?? 'producto'}-${offset + index}`,
-              name: String(
-                product?.name ?? product?.nom_externo ?? 'Producto sin nombre'
-              ),
-              code: product?.code ?? product?.cod_externo ?? null,
-              price: Number(product?.price ?? product?.precio_final ?? 0),
-              date: product?.date ?? product?.fecha ?? null,
-              companyType: product?.companyType ?? product?.tipo_empresa ?? null,
-              family: product?.family ?? product?.familia ?? null,
-              isActive: Boolean(product?.isActive ?? product?.is_active ?? false),
-            }))
-          : [];
-
-        const parsedTotal = Number(data?.total);
-        setProducts((prev) =>
-          offset === 0 ? normalizedProducts : [...prev, ...normalizedProducts]
-        );
-        setTotal(Number.isFinite(parsedTotal) ? parsedTotal : null);
-      } catch (error) {
-        if (!isActive) return;
-        console.error('Error fetching provider products:', error);
-        setProductsError(
-          error instanceof Error && error.message
-            ? error.message
-            : 'No se pudieron cargar los productos de este proveedor.'
-        );
-        if (offset > 0) {
-          skipNextFetchRef.current = true;
-          setOffset((current) => Math.max(0, current - limit));
-        }
-      } finally {
-        if (!isActive) return;
-        if (offset === 0) {
-          setLoadingProducts(false);
-        }
-        loadingMoreRef.current = false;
-        setLoadingMore(false);
-      }
-    };
-
-    fetchProducts();
-
-    return () => {
-      isActive = false;
-    };
-  }, [providerName, offset, limit]);
-
-  const handleModalScroll: React.UIEventHandler<HTMLDivElement> = (event) => {
-    if (!selectedProvider || loadingProducts || loadingMoreRef.current) {
-      return;
-    }
-    if (typeof total !== 'number' || products.length >= total) {
-      return;
-    }
-
-    const target = event.currentTarget;
-    const distanceFromBottom = target.scrollHeight - target.scrollTop - target.clientHeight;
-    if (distanceFromBottom < 200) {
-      loadingMoreRef.current = true;
-      setLoadingMore(true);
-      setOffset((current) => current + limit);
-    }
-  };
+      : selectedProvider?.products ?? loadedCount ?? displayedProducts.length;
 
   const getOriginalComparableValue = (
     product: ProviderProduct,
@@ -983,12 +930,12 @@ const ActiveSuppliersScreen: React.FC<ActiveSuppliersScreenProps> = ({ onNavigat
 
               <div
                 className="flex max-h-[calc(90vh-140px)] flex-col gap-4 overflow-y-auto px-6 py-5"
-                onScroll={handleModalScroll}
               >
                 <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                   <div className="text-sm text-gray-600 dark:text-white/70">
                     Mostrando {displayedProducts.length.toLocaleString('es-AR')} de{' '}
-                    {totalProductsCount.toLocaleString('es-AR')} productos
+                    {totalProductsCount.toLocaleString('es-AR')} productos ·{' '}
+                    {loadedCount.toLocaleString('es-AR')} cargados
                   </div>
                   <label className="relative w-full md:w-80">
                     <span className="sr-only">Buscar productos</span>
@@ -1008,12 +955,19 @@ const ActiveSuppliersScreen: React.FC<ActiveSuppliersScreenProps> = ({ onNavigat
                 </div>
 
                 {productsError && (
-                  <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-200">
-                    {productsError}
+                  <div className="flex flex-wrap items-center gap-3 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-200">
+                    <span>{productsError}</span>
+                    <button
+                      type="button"
+                      onClick={reloadProducts}
+                      className="inline-flex items-center rounded-full border border-red-300 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-red-700 transition hover:border-red-400 hover:text-red-900 dark:border-red-500/50 dark:text-red-200"
+                    >
+                      Reintentar
+                    </button>
                   </div>
                 )}
 
-                {loadingProducts ? (
+                {isLoadingInitial ? (
                   <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-white/70">
                     <Loader2 className="h-4 w-4 animate-spin" />
                     Cargando productos del proveedor...
@@ -1157,7 +1111,7 @@ const ActiveSuppliersScreen: React.FC<ActiveSuppliersScreenProps> = ({ onNavigat
                       })}
                     </div>
 
-                    {loadingMore && (
+                    {isLoadingMore && (
                       <div className="flex items-center justify-center gap-2 py-4 text-sm text-gray-600 dark:text-white/70">
                         <Loader2 className="h-4 w-4 animate-spin" />
                         Cargando más productos...

--- a/project/src/screens/venta/UnmatchedEquivalencesScreen.tsx
+++ b/project/src/screens/venta/UnmatchedEquivalencesScreen.tsx
@@ -3,7 +3,8 @@ import { Button } from '../../components/Button';
 import { Navigation } from '../../components/Navigation';
 import { Screen } from '../../types';
 import { apiFetch } from '../../lib/api';
-import { Trash2 } from 'lucide-react';
+import { Loader2, Trash2 } from 'lucide-react';
+import { useProgressiveBatchLoader } from '../../hooks/useProgressiveBatchLoader';
 import { formatYMD, compareYMD, formatYearMonth, compareYearMonth } from '../../utils/date';
 import { isFiniteNumber, safeToFixed } from '../../utils/number';
 import { getBestSearchRank, normalizeSearchTerm } from '../../utils/search';
@@ -148,13 +149,6 @@ type PaginatedResult<T> = {
   hasMore: boolean;
 };
 
-type PaginationMeta = {
-  total: number;
-  limit: number;
-  offset: number;
-  hasMore: boolean;
-};
-
 const DEFAULT_SIMILARITY_THRESHOLD = 0.40;
 const MAX_CANDIDATES_PER_INTERNAL = Infinity;
 const BATCH_SIZE = 200;
@@ -177,13 +171,6 @@ const normalizeInternalRows = (rows: any[]): InternalItem[] =>
       cod_interno: item?.cod_interno ?? item?.codigo ?? null,
     }))
     .filter((item) => Number.isFinite(item.id_interno) && item.id_interno > 0);
-
-const createInitialMeta = (): PaginationMeta => ({
-  offset: 0,
-  limit: PAGINATION_PAGE_SIZE,
-  total: 0,
-  hasMore: false,
-});
 
 const buildPaginationResult = <T,>(
   data: any,
@@ -225,18 +212,20 @@ const buildPaginationResult = <T,>(
 
 const fetchPaginatedChunk = async <T,>(
   path: string,
-  offset: number
+  offset: number,
+  limit: number,
+  signal?: AbortSignal
 ): Promise<PaginatedResult<T>> => {
   const params = new URLSearchParams();
-  params.set('limit', String(PAGINATION_PAGE_SIZE));
+  params.set('limit', String(limit));
   params.set('offset', String(offset));
 
-  const res = await apiFetch(`${path}?${params.toString()}`);
+  const res = await apiFetch(`${path}?${params.toString()}`, { signal });
   if (!res.ok) {
     throw new Error(`request_failed:${path}`);
   }
   const data = await res.json();
-  return buildPaginationResult<T>(data, PAGINATION_PAGE_SIZE, offset);
+  return buildPaginationResult<T>(data, limit, offset);
 };
 
 const sortIcon = (dir?: SortDir) =>
@@ -284,14 +273,6 @@ const SearchInput: React.FC<{ value: string; onChange: (v: string) => void; plac
 );
 
 export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen) => void }> = ({ onNavigate }) => {
-  const [externals, setExternals] = useState<ExternalItem[]>([]);
-  const [internals, setInternals] = useState<InternalItem[]>([]);
-  const [externalMeta, setExternalMeta] = useState<PaginationMeta>(() => createInitialMeta());
-  const [internalMeta, setInternalMeta] = useState<PaginationMeta>(() => createInitialMeta());
-  const [loadingMoreExternals, setLoadingMoreExternals] = useState(false);
-  const [loadingMoreInternals, setLoadingMoreInternals] = useState(false);
-  const [loadingExternals, setLoadingExternals] = useState(true);
-  const [loadingInternals, setLoadingInternals] = useState(true);
   const [selectedExternals, setSelectedExternals] = useState<ExternalItem[]>([]);
   const [selectedInternal, setSelectedInternal] = useState<InternalItem | null>(null);
 
@@ -314,6 +295,67 @@ export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen
   const dSearchExt = useDeferredValue(searchExt);
   const dSearchInt = useDeferredValue(searchInt);
 
+  const fetchExternalPage = useCallback(
+    async (offset: number, limit: number, signal: AbortSignal) => {
+      const page = await fetchPaginatedChunk<any>(
+        '/api/no-relacionados/proveedores',
+        offset,
+        limit,
+        signal
+      );
+      return {
+        items: normalizeExternalRows(page.items),
+        total: page.total,
+        hasMore: page.hasMore,
+      };
+    },
+    []
+  );
+
+  const {
+    items: externals,
+    setItems: setExternals,
+    total: externalTotal,
+    setTotal: setExternalTotal,
+    loadedCount: externalLoadedCount,
+    isLoadingInitial: loadingExternals,
+    isLoadingMore: loadingMoreExternals,
+    error: externalsError,
+    reload: reloadExternals,
+  } = useProgressiveBatchLoader<ExternalItem>({
+    enabled: true,
+    limit: PAGINATION_PAGE_SIZE,
+    fetchPage: fetchExternalPage,
+  });
+
+  const fetchInternalPage = useCallback(
+    async (offset: number, limit: number, signal: AbortSignal) => {
+      const page = await fetchPaginatedChunk<any>('/api/gampack', offset, limit, signal);
+      return {
+        items: normalizeInternalRows(page.items),
+        total: page.total,
+        hasMore: page.hasMore,
+      };
+    },
+    []
+  );
+
+  const {
+    items: internals,
+    setItems: setInternals,
+    total: internalTotal,
+    setTotal: setInternalTotal,
+    loadedCount: internalLoadedCount,
+    isLoadingInitial: loadingInternals,
+    isLoadingMore: loadingMoreInternals,
+    error: internalsError,
+    reload: reloadInternals,
+  } = useProgressiveBatchLoader<InternalItem>({
+    enabled: true,
+    limit: PAGINATION_PAGE_SIZE,
+    fetchPage: fetchInternalPage,
+  });
+
   // ordenamientos
   const [sortExtKey, setSortExtKey] = useState<SortKeyExternal>('fecha');
   const [sortExtDir, setSortExtDir] = useState<SortDir>('desc');
@@ -326,103 +368,6 @@ export const UnmatchedEquivalencesScreen: React.FC<{ onNavigate: (screen: Screen
 
   // Top button
   const [showTop, setShowTop] = useState(false);
-
-  useEffect(() => {
-    let aborted = false;
-
-    const loadTables = async () => {
-      setLoadingExternals(true);
-      setLoadingInternals(true);
-      try {
-        const [externalPage, internalPage] = await Promise.all([
-          fetchPaginatedChunk<any>('/api/no-relacionados/proveedores', 0),
-          fetchPaginatedChunk<any>('/api/gampack', 0),
-        ]);
-
-        if (aborted) return;
-
-        const normalizedExternal = normalizeExternalRows(externalPage.items);
-        const normalizedInternal = normalizeInternalRows(internalPage.items);
-
-        setExternals(normalizedExternal);
-        setInternals(normalizedInternal);
-        setExternalMeta({
-          offset: externalPage.offset + externalPage.items.length,
-          limit: externalPage.limit,
-          total: externalPage.total,
-          hasMore: externalPage.hasMore,
-        });
-        setInternalMeta({
-          offset: internalPage.offset + internalPage.items.length,
-          limit: internalPage.limit,
-          total: internalPage.total,
-          hasMore: internalPage.hasMore,
-        });
-      } catch (error) {
-        console.error('Error cargando productos para vinculación manual:', error);
-        if (!aborted) {
-          setExternals([]);
-          setInternals([]);
-          setExternalMeta(createInitialMeta());
-          setInternalMeta(createInitialMeta());
-        }
-      } finally {
-        if (!aborted) {
-          setLoadingExternals(false);
-          setLoadingInternals(false);
-        }
-      }
-    };
-
-    loadTables();
-    return () => {
-      aborted = true;
-    };
-  }, []);
-
-  const loadMoreExternals = async () => {
-    if (loadingMoreExternals || loadingExternals || !externalMeta.hasMore) return;
-    setLoadingMoreExternals(true);
-    try {
-      const page = await fetchPaginatedChunk<any>('/api/no-relacionados/proveedores', externalMeta.offset);
-      const chunkLength = page.items.length;
-      const normalized = normalizeExternalRows(page.items);
-      setExternals((prev) => [...prev, ...normalized]);
-      setExternalMeta({
-        offset: page.offset + chunkLength,
-        limit: page.limit,
-        total: page.total,
-        hasMore: page.hasMore,
-      });
-    } catch (error) {
-      console.error('Error cargando más productos externos:', error);
-      alert('No se pudieron cargar más productos de proveedores.');
-    } finally {
-      setLoadingMoreExternals(false);
-    }
-  };
-
-  const loadMoreInternals = async () => {
-    if (loadingMoreInternals || loadingInternals || !internalMeta.hasMore) return;
-    setLoadingMoreInternals(true);
-    try {
-      const page = await fetchPaginatedChunk<any>('/api/gampack', internalMeta.offset);
-      const chunkLength = page.items.length;
-      const normalized = normalizeInternalRows(page.items);
-      setInternals((prev) => [...prev, ...normalized]);
-      setInternalMeta({
-        offset: page.offset + chunkLength,
-        limit: page.limit,
-        total: page.total,
-        hasMore: page.hasMore,
-      });
-    } catch (error) {
-      console.error('Error cargando más productos Gampack:', error);
-      alert('No se pudieron cargar más productos Gampack.');
-    } finally {
-      setLoadingMoreInternals(false);
-    }
-  };
 
 
   // accesos rápidos teclado
@@ -540,12 +485,18 @@ const generateAutoMatches = useCallback(async () => {
 
   /* ---------- Aceptar / Rechazar sugerencias ---------- */
   const removeFromStateAfterLink = (i: InternalItem, e: ExternalItem) => {
-  setExternals(prev => prev.filter(x => x.id_externo !== e.id_externo)); // solo quitamos el externo
-  // ✅ no quitamos el producto Gampack del estado
-  setSelectedExternals(prev => prev.filter(x => x.id_externo !== e.id_externo));
-  setSelectedInternal(prev => (prev?.id_interno === i.id_interno ? null : prev));
-  setSuggestions(prev => prev.filter(s => s.internal.id_interno !== i.id_interno && s.external.id_externo !== e.id_externo));
-};
+    setExternals((prev) => prev.filter((x) => x.id_externo !== e.id_externo)); // solo quitamos el externo
+    setExternalTotal((current) =>
+      typeof current === 'number' ? Math.max(0, current - 1) : current
+    );
+    setSelectedExternals((prev) => prev.filter((x) => x.id_externo !== e.id_externo));
+    setSelectedInternal((prev) => (prev?.id_interno === i.id_interno ? null : prev));
+    setSuggestions((prev) =>
+      prev.filter(
+        (s) => s.internal.id_interno !== i.id_interno && s.external.id_externo !== e.id_externo
+      )
+    );
+  };
 
   const acceptSuggestion = async (s: Suggestion) => {
     try {
@@ -582,6 +533,12 @@ const generateAutoMatches = useCallback(async () => {
         if (!res.ok) throw new Error('No se pudo vincular en lote');
         setExternals(prev => prev.filter(e => !extIds.includes(e.id_externo)));
         setInternals(prev => prev.filter(i => i.id_interno !== internal.id_interno));
+        setExternalTotal((current) =>
+          typeof current === 'number' ? Math.max(0, current - extIds.length) : current
+        );
+        setInternalTotal((current) =>
+          typeof current === 'number' ? Math.max(0, current - 1) : current
+        );
         setSuggestions(prev => prev.filter(s => s.internal.id_interno !== internal.id_interno));
       }
       toast(`✔ Vinculadas ${suggestions.length} sugerencias`);
@@ -709,6 +666,9 @@ const generateAutoMatches = useCallback(async () => {
       for (const id of ids) await apiFetch(`/api/no-relacionados/externos/${id}`, { method: 'DELETE' }).catch(() => {});
     } finally {
       setExternals(prev => prev.filter(x => !extDeleteIds.has(x.id_externo)));
+      setExternalTotal((current) =>
+        typeof current === 'number' ? Math.max(0, current - ids.length) : current
+      );
       setSelectedExternals(prev => prev.filter(x => !extDeleteIds.has(x.id_externo)));
       setExtDeleteIds(new Set());
       setDeleteModeExt(false);
@@ -729,6 +689,9 @@ const generateAutoMatches = useCallback(async () => {
       for (const id of ids) await apiFetch(`/api/no-relacionados/internos/${id}`, { method: 'DELETE' }).catch(() => {});
     } finally {
       setInternals(prev => prev.filter(x => !intDeleteIds.has(x.id_interno)));
+      setInternalTotal((current) =>
+        typeof current === 'number' ? Math.max(0, current - ids.length) : current
+      );
       if (selectedInternal && intDeleteIds.has(selectedInternal.id_interno)) setSelectedInternal(null);
       setIntDeleteIds(new Set());
       setDeleteModeInt(false);
@@ -747,6 +710,9 @@ const generateAutoMatches = useCallback(async () => {
       });
       if (res.ok) {
         setExternals(prev => prev.filter(e => !selectedExternals.some(se => se.id_externo === e.id_externo)));
+        setExternalTotal((current) =>
+          typeof current === 'number' ? Math.max(0, current - selectedExternals.length) : current
+        );
         setSelectedExternals([]); setSelectedInternal(null);
         setSuggestions(prev => prev.filter(s => s.internal.id_interno !== selectedInternal.id_interno && !selectedExternals.some(se => se.id_externo === s.external.id_externo)));
         toast('✔ Vinculación manual realizada');
@@ -859,9 +825,9 @@ const generateAutoMatches = useCallback(async () => {
                   <p className="text-xs text-gray-500 dark:text-gray-400">
                     {loadingExternals
                       ? 'Cargando productos…'
-                      : externalMeta.total > 0
-                        ? `${externals.length.toLocaleString('es-AR')} de ${externalMeta.total.toLocaleString('es-AR')} productos`
-                        : `${externals.length.toLocaleString('es-AR')} productos`}
+                      : typeof externalTotal === 'number'
+                        ? `${externalLoadedCount.toLocaleString('es-AR')} de ${externalTotal.toLocaleString('es-AR')} productos`
+                        : `${externalLoadedCount.toLocaleString('es-AR')} productos cargados`}
                   </p>
                 </div>
                 <div className="flex items-center gap-2">
@@ -883,6 +849,15 @@ const generateAutoMatches = useCallback(async () => {
               <div className="mb-3">
                 <SearchInput value={searchExt} onChange={setSearchExt} placeholder="Buscar por código, nombre o proveedor…" />
               </div>
+
+              {externalsError && (
+                <div className="mb-3 flex flex-wrap items-center gap-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-200">
+                  <span>{externalsError}</span>
+                  <Button onClick={reloadExternals} variant="secondary">
+                    Reintentar
+                  </Button>
+                </div>
+              )}
 
               <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-white/10 shadow-sm bg-white dark:bg-[#0f1930]">
                 <table className="min-w-full divide-y divide-gray-200 dark:divide-white/10 text-sm">
@@ -932,11 +907,10 @@ const generateAutoMatches = useCallback(async () => {
                   </tbody>
                 </table>
               </div>
-              {externalMeta.hasMore && (
-                <div className="mt-3 flex justify-center">
-                  <Button onClick={loadMoreExternals} disabled={loadingMoreExternals}>
-                    {loadingMoreExternals ? 'Cargando más…' : 'Cargar más'}
-                  </Button>
+              {loadingMoreExternals && (
+                <div className="mt-3 flex items-center justify-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Cargando más productos...
                 </div>
               )}
               <div className="mt-2 text-xs text-gray-600 dark:text-gray-400">
@@ -952,9 +926,9 @@ const generateAutoMatches = useCallback(async () => {
                   <p className="text-xs text-gray-500 dark:text-gray-400">
                     {loadingInternals
                       ? 'Cargando productos…'
-                      : internalMeta.total > 0
-                        ? `${internals.length.toLocaleString('es-AR')} de ${internalMeta.total.toLocaleString('es-AR')} productos`
-                        : `${internals.length.toLocaleString('es-AR')} productos`}
+                      : typeof internalTotal === 'number'
+                        ? `${internalLoadedCount.toLocaleString('es-AR')} de ${internalTotal.toLocaleString('es-AR')} productos`
+                        : `${internalLoadedCount.toLocaleString('es-AR')} productos cargados`}
                   </p>
                 </div>
                 <div className="flex items-center gap-2">
@@ -976,6 +950,15 @@ const generateAutoMatches = useCallback(async () => {
               <div className="mb-3">
                 <SearchInput value={searchInt} onChange={setSearchInt} placeholder="Buscar por código o nombre…" />
               </div>
+
+              {internalsError && (
+                <div className="mb-3 flex flex-wrap items-center gap-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-200">
+                  <span>{internalsError}</span>
+                  <Button onClick={reloadInternals} variant="secondary">
+                    Reintentar
+                  </Button>
+                </div>
+              )}
 
               <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-white/10 shadow-sm bg-white dark:bg-[#0f1930]">
                 <table className="min-w-full divide-y divide-gray-200 dark:divide-white/10 text-sm">
@@ -1029,11 +1012,10 @@ const generateAutoMatches = useCallback(async () => {
                   </tbody>
                 </table>
               </div>
-              {internalMeta.hasMore && (
-                <div className="mt-3 flex justify-center">
-                  <Button onClick={loadMoreInternals} disabled={loadingMoreInternals}>
-                    {loadingMoreInternals ? 'Cargando más…' : 'Cargar más'}
-                  </Button>
+              {loadingMoreInternals && (
+                <div className="mt-3 flex items-center justify-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Cargando más productos...
                 </div>
               )}
               <div className="mt-2 text-xs text-gray-600 dark:text-gray-400">


### PR DESCRIPTION
## Summary
- add a reusable progressive batch loading hook and update the Active Suppliers screen to fetch all products in background instead of using scroll-triggered pagination
- rework the Unmatched Equivalences screen to load all external and internal products progressively, refresh the search UX, and surface loading/error indicators
- update the backend product endpoints to honour limit/offset parameters and report pagination metadata for the new loaders

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917570dfbd8832d819c599b43d78b64)